### PR TITLE
general: Grant service read/write permission on state directory

### DIFF
--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -27,6 +27,7 @@ ProtectHome=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectSystem=strict
+ReadWritePaths=@localstatedir@/lib/eos-payg
 RestrictAddressFamilies=AF_UNIX
 RestrictRealtime=yes
 SystemCallErrorNumber=EPERM

--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -23,6 +23,7 @@ executable('eos-paygd' + eos_paygd_api_version,
 config = configuration_data()
 config.set('DAEMON_USER', get_option('payg_daemon_user'))
 config.set('libexecdir', join_paths(get_option('prefix'), get_option('libexecdir')))
+config.set('localstatedir', join_paths(get_option('prefix'), get_option('localstatedir')))
 
 configure_file(
   input: 'com.endlessm.Payg1.conf.in',


### PR DESCRIPTION
The eos-paygd service is configured with ProtectSystem=strict, meaning
that most of the file system hierarchy is mounted read-only [1]. This
prevents the daemon from writing the state files in /var/lib/eos-payg,
so add an exception for that directory, so that things actually work.

[1] https://www.freedesktop.org/software/systemd/man/systemd.exec.html

https://phabricator.endlessm.com/T21615