### PR TITLE
libeos-payg: Fix location for shared key

### DIFF
--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -179,7 +179,7 @@ epg_service_startup_async (HlpService          *service,
    * might not be one installed on this image. */
   if (enabled)
     {
-      g_autoptr(GFile) key_file = g_file_new_for_path (DATADIR "/eos-payg/key");
+      g_autoptr(GFile) key_file = g_file_new_for_path (PREFIX "/local/share/eos-payg/key");
 
       g_file_load_contents_async (key_file, cancellable,
                                   load_key_cb, g_steal_pointer (&task));


### PR DESCRIPTION
It needs to be in /usr/local/share/eos-payg, rather than
/usr/share/eos-payg, so that the image builder can drop the key into the
image, rather than it having to be in the OSTree.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T21619