### PR TITLE
debian: Lower libglib2.0-dev requirement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 10),
  dh-python,
  dh-systemd,
- libglib2.0-dev (>= 2.54.2-1endless2),
+ libglib2.0-dev (>= 2.54.2),
  libsystemd-dev,
  meson,
  python3-dbusmock,


### PR DESCRIPTION
We don’t actually depend on the changes which were introduced in
*-1endless2; we just depend on API introduced in the 2.54 major release.

Lower the dependency to avoid problems with backporting to eos3.3.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T21730