### PR TITLE
debian: Lower systemd requirement to 232 for eos3.3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: misc
 Architecture: any
 Multi-arch: same
 Depends:
- systemd (>= 235),
+ systemd (>= 232),
  ${misc:Depends},
  ${shlibs:Depends},
 Description: Pay As You Go Daemon

--- a/debian/eos-paygd.install
+++ b/debian/eos-paygd.install
@@ -1,6 +1,7 @@
 lib/systemd/system/eos-paygd.service
 usr/lib/*/eos-paygd1
 usr/lib/sysusers.d/eos-paygd.conf
+usr/lib/tmpfiles.d/eos-paygd.conf
 usr/share/dbus-1/system.d/com.endlessm.Payg1.conf
 usr/share/dbus-1/system-services/com.endlessm.Payg1.service
 usr/share/man/man5/eos-payg.conf.5*

--- a/debian/eos-paygd.postinst
+++ b/debian/eos-paygd.postinst
@@ -3,6 +3,7 @@ set -e
 
 if [ "$1" = configure ]; then
     systemd-sysusers /lib/sysusers.d/eos-paygd.conf
+    systemd-tmpfiles --create /lib/tmpfiles.d/eos-paygd.conf
 fi
 
 #DEBHELPER#

--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -2,6 +2,8 @@
 Description=Pay As You Go Daemon
 Documentation=man:eos-paygd(8)
 Before=systemd-user-sessions.service
+Requires=systemd-tmpfiles-setup.service
+After=systemd-tmpfiles-setup.service
 
 [Service]
 ExecStart=@libexecdir@/eos-paygd1
@@ -27,8 +29,7 @@ ProtectHome=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectSystem=strict
-StateDirectory=eos-payg
-StateDirectoryMode=0700
+ReadWritePaths=/var/lib/eos-payg
 RestrictAddressFamilies=AF_UNIX
 RestrictRealtime=yes
 SystemCallErrorNumber=EPERM

--- a/eos-paygd/eos-paygd.tmpfiles.conf.in
+++ b/eos-paygd/eos-paygd.tmpfiles.conf.in
@@ -1,0 +1,18 @@
+# Copyright © 2018 Endless Mobile, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Alternatively, the contents of this file may be used under the terms of the
+# GNU Lesser General Public License Version 2.1 or later (the "LGPL"), in
+# which case the provisions of the LGPL are applicable instead of those above.
+# If you wish to allow use of your version of this file only under the terms
+# of the LGPL, and not to allow others to use your version of this file under
+# the terms of the MPL, indicate your decision by deleting the provisions
+# above and replace them with the notice and other provisions required by the
+# LGPL. If you do not delete the provisions above, a recipient may use your
+# version of this file under the terms of either the MPL or the LGPL.
+#
+# Type Path                         Mode UID           GID           Age Argument
+d      @localstatedir@/lib/eos-payg 0700 @DAEMON_USER@ @DAEMON_USER@ -   -

--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -23,6 +23,7 @@ executable('eos-paygd' + eos_paygd_api_version,
 config = configuration_data()
 config.set('DAEMON_USER', get_option('payg_daemon_user'))
 config.set('libexecdir', join_paths(get_option('prefix'), get_option('libexecdir')))
+config.set('localstatedir', join_paths(get_option('prefix'), get_option('localstatedir')))
 
 configure_file(
   input: 'com.endlessm.Payg1.conf.in',
@@ -40,6 +41,12 @@ configure_file(
   input: 'eos-paygd.conf.in',
   output: 'eos-paygd.conf',
   install_dir: dependency('systemd').get_pkgconfig_variable('sysusersdir'),
+  configuration: config,
+)
+configure_file(
+  input: 'eos-paygd.tmpfiles.conf.in',
+  output: 'eos-paygd.conf',
+  install_dir: dependency('systemd').get_pkgconfig_variable('tmpfilesdir'),
   configuration: config,
 )
 configure_file(


### PR DESCRIPTION
**When based on top of #14, this should be renamed to the `eos3.3` branch and pushed as that. Hopefully it will build on eos3.3. This branch should not be merged to master.**

This requires reworking how the state directory is created, since the
StateDirectory= key was only added in systemd 235. Drop that, and use
tmpfiles.d instead to create the directory.

This patch should not be applied to master, as we can depend on systemd
235 there, and things are a bit cleaner.

Signed-off-by: Philip Withnall <withnall@endlessm.com>
https://phabricator.endlessm.com/T21730