### PR TITLE
tests: Port from python3.5 to python3.4

### DIFF
--- a/eos-paygd/tests/eos-paygd.py
+++ b/eos-paygd/tests/eos-paygd.py
@@ -58,13 +58,15 @@ class TestEosPaygd(dbusmock.DBusTestCase):
     @unittest.skipIf(os.geteuid() != 0, "Must be run as root")
     def test_abort_if_root(self):
         """Test the daemon exits immediately if run as root."""
-        info = subprocess.run([self.__eos_paygd],
-                              timeout=self.timeout_seconds,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT)
-        out = info.stdout.decode('utf-8').strip()
+        p = subprocess.Popen([self.__eos_paygd],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        out, _ = p.communicate(timeout=self.timeout_seconds)
+        rc = p.returncode
+
+        out = out.decode('utf-8').strip()
         self.assertIn('This daemon must not be run as root', out)
-        self.assertEqual(info.returncode, 3)  # ERROR_INVALID_ENVIRONMENT
+        self.assertEqual(rc, 3)  # ERROR_INVALID_ENVIRONMENT
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
eos3.3 only has python3.4, which doesn’t support the new
subprocess.run() method, so we need to backport the tests to use an
unholy combination of subprocess.check_output() and subprocess.Popen().

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T21730