### PR TITLE
debian: Call systemd-sysusers on correct path in paygd postinst

### DIFF
--- a/debian/eos-paygd.postinst
+++ b/debian/eos-paygd.postinst
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$1" = configure ]; then
-    systemd-sysusers /lib/sysusers.d/eos-paygd.conf
+    systemd-sysusers /usr/lib/sysusers.d/eos-paygd.conf
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
The sysusers configuration is installed at
/usr/lib/sysusers.d/eos-paygd.conf, but systemd-sysusers was being
called with the path in /lib. This works in the ostree builder where
/lib is a symlink to /usr/lib, but not in OBS where that's not the case.

https://phabricator.endlessm.com/T23969