### PR TITLE
Improve compiler flag detection; set Enabled=true by default

### DIFF
--- a/eos-paygd/eos-payg.conf
+++ b/eos-paygd/eos-payg.conf
@@ -1,2 +1,2 @@
 [PAYG]
-Enabled=false
+Enabled=true

--- a/meson.build
+++ b/meson.build
@@ -107,11 +107,7 @@ test_args = [
   '-Wwrite-strings'
 ]
 cc = meson.get_compiler('c')
-foreach arg: test_args
-  if cc.has_argument(arg)
-    add_project_arguments(arg, language : 'c')
-  endif
-endforeach
+add_project_arguments(cc.get_supported_arguments(test_args), language: 'c')
 
 enable_installed_tests = get_option('installed_tests')
 test_template = files('template.test.in')


### PR DESCRIPTION
A few bits of mutually-unrelated followup:

* My intention on https://github.com/endlessm/eos-payg/pull/24 was that creating the key file should be all that's needed to enable Endless PAYG on a system, but I didn't actually implement that change.
* On a related pull request I learned that cc.get_supported_arguments() exists.

https://phabricator.endlessm.com/T23606