### PR TITLE
eos-payg-ctl: add --bus-address argument; tweak code style

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+# Accept the output of https://github.com/ambv/black
+[flake8]
+max-line-length = 88
+ignore = E203, W503

--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -24,12 +24,12 @@ import sys
 from dateutil import tz
 from gi.repository import GLib, Gio
 
-BUS_NAME = 'com.endlessm.Payg1'
-OBJECT_PATH = '/com/endlessm/Payg1'
-INTERFACE = 'com.endlessm.Payg1'
-ERROR_DOMAIN = 'com.endlessm.Payg1.Error'
+BUS_NAME = "com.endlessm.Payg1"
+OBJECT_PATH = "/com/endlessm/Payg1"
+INTERFACE = "com.endlessm.Payg1"
+ERROR_DOMAIN = "com.endlessm.Payg1.Error"
 
-DBUS_PROPERTIES_INTERFACE = 'org.freedesktop.DBus.Properties'
+DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 
 def __format_utc_timestamp(timestamp):
@@ -51,7 +51,7 @@ def __get_proxy():
 
 
 def command_status(proxy):
-    '''Show the current PAYG status of this device.'''
+    """Show the current PAYG status of this device."""
     props = {
         name: proxy.get_cached_property(name).unpack()
         for name in proxy.get_cached_property_names()
@@ -59,13 +59,13 @@ def command_status(proxy):
 
     width = max(map(len, props), default=0)
     formatters = {
-        'ExpiryTime': __format_utc_timestamp,
-        'RateLimitEndTime': __format_utc_timestamp,
+        "ExpiryTime": __format_utc_timestamp,
+        "RateLimitEndTime": __format_utc_timestamp,
     }
 
     for key, value in sorted(props.items()):
         formatted = formatters.get(key, lambda x: x)(value)
-        print('{:>{}}: {}'.format(key, width, formatted))
+        print("{:>{}}: {}".format(key, width, formatted))
 
 
 @contextlib.contextmanager
@@ -85,21 +85,21 @@ def __exit_on_payg_error():
         # Gio.dbus_error_get_remote_error(e) does not modify e.message,
         # presumably because the Python-side GLib.GError is marshalled back to
         # a new temporary C-side GError.
-        message = e.message[e.message.index(remote_error):]
+        message = e.message[e.message.index(remote_error) :]
         print(message, file=sys.stderr, flush=True)
         raise SystemExit(1)
 
 
 def command_add_code(proxy, code):
-    '''Verify and add the given code, assuming it has not already been used,
-    and extend the expiry time as appropriate.'''
+    """Verify and add the given code, assuming it has not already been used,
+    and extend the expiry time as appropriate."""
     with __exit_on_payg_error():
-        proxy.AddCode('(s)', code)
+        proxy.AddCode("(s)", code)
 
 
 def command_clear_code(proxy):
-    '''Clear the current code(s), causing any remaining credit to expire
-    immediately. This is typically intended to be used for testing.'''
+    """Clear the current code(s), causing any remaining credit to expire
+    immediately. This is typically intended to be used for testing."""
     with __exit_on_payg_error():
         proxy.ClearCode()
 
@@ -107,22 +107,21 @@ def command_clear_code(proxy):
 def main():
     parser = argparse.ArgumentParser()
     parser.set_defaults(function=command_status)
-    subparsers = parser.add_subparsers(title='subcommands')
+    subparsers = parser.add_subparsers(title="subcommands")
 
     def add_parser(name, function):
-        p = subparsers.add_parser(name,
-                                  help=function.__doc__,
-                                  description=function.__doc__)
+        p = subparsers.add_parser(
+            name, help=function.__doc__, description=function.__doc__
+        )
         p.set_defaults(function=function)
         return p
 
-    add_parser('status', command_status)
+    add_parser("status", command_status)
 
-    add_code = add_parser('add-code', command_add_code)
-    add_code.add_argument('code',
-                          help='a new PAYG code')
+    add_code = add_parser("add-code", command_add_code)
+    add_code.add_argument("code", help="a new PAYG code")
 
-    add_parser('clear-code', command_clear_code)
+    add_parser("clear-code", command_clear_code)
 
     args = parser.parse_args()
     function = args.function
@@ -132,5 +131,5 @@ def main():
     function(proxy, **vars(args))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -20,6 +20,7 @@
 import argparse
 import contextlib
 import datetime as dt
+import posix
 import sys
 from dateutil import tz
 from gi.repository import GLib, Gio
@@ -38,9 +39,20 @@ def __format_utc_timestamp(timestamp):
     return str(expiry_local)
 
 
-def __get_proxy():
-    return Gio.DBusProxy.new_for_bus_sync(
-        Gio.BusType.SYSTEM,
+def __get_proxy(bus_address):
+    if bus_address is not None:
+        bus = Gio.DBusConnection.new_for_address_sync(
+            bus_address,
+            Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT
+            | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
+            None,
+            None,
+        )
+    else:
+        bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+
+    proxy = Gio.DBusProxy.new_sync(
+        bus,
         Gio.DBusProxyFlags.NONE,
         None,
         BUS_NAME,
@@ -48,6 +60,10 @@ def __get_proxy():
         INTERFACE,
         None,  # cancellable
     )
+    if proxy.get_name_owner() is None:
+        print("Error: could not rouse {}".format(BUS_NAME), file=sys.stderr, flush=True)
+        exit(posix.EX_UNAVAILABLE)
+    return proxy
 
 
 def command_status(proxy):
@@ -107,6 +123,12 @@ def command_clear_code(proxy):
 def main():
     parser = argparse.ArgumentParser()
     parser.set_defaults(function=command_status)
+    parser.add_argument(
+        "-a",
+        "--bus-address",
+        metavar="ADDRESS",
+        help="Address of the D-Bus daemon to use (default: the system bus)",
+    )
     subparsers = parser.add_subparsers(title="subcommands")
 
     def add_parser(name, function):
@@ -124,11 +146,13 @@ def main():
     add_parser("clear-code", command_clear_code)
 
     args = parser.parse_args()
-    function = args.function
-    del args.function
 
-    proxy = __get_proxy()
-    function(proxy, **vars(args))
+    kwargs = vars(args)
+    function = kwargs.pop("function")
+    bus_address = kwargs.pop("bus_address")
+
+    proxy = __get_proxy(bus_address)
+    function(proxy, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`-a` and `--bus-address` matches the short and long names used by the daemon (courtesy of libgsystemservice), and is useful when running a development copy of the daemon on the session bus.

https://github.com/ambv/black is a reasonable (and reasonably popular) auto-formatter for Python code. In a few places, it disagrees with flake8's defaults; tweak flake8 to ignore these.

Perhaps in a future life I'll make flake8- and black-cleanliness a compile-time check.

Preliminary work for https://phabricator.endlessm.com/T23781