### PR TITLE
eos-payg: Return the amount of time added

### DIFF
--- a/libeos-payg/manager-interface.h
+++ b/libeos-payg/manager-interface.h
@@ -38,10 +38,22 @@ static const GDBusArgInfo manager_interface_add_code_arg_code =
   (gchar *) "s",
   NULL
 };
+static const GDBusArgInfo manager_interface_add_code_arg_time_added =
+{
+  -1,  /* ref count */
+  (gchar *) "time_added",
+  (gchar *) "x",
+  NULL
+};
 
 static const GDBusArgInfo *manager_interface_add_code_in_args[] =
 {
   &manager_interface_add_code_arg_code,
+  NULL,
+};
+static const GDBusArgInfo *manager_interface_add_code_out_args[] =
+{
+  &manager_interface_add_code_arg_time_added,
   NULL,
 };
 static const GDBusMethodInfo manager_interface_add_code =
@@ -49,7 +61,7 @@ static const GDBusMethodInfo manager_interface_add_code =
   -1,  /* ref count */
   (gchar *) "AddCode",
   (GDBusArgInfo **) manager_interface_add_code_in_args,
-  NULL,  /* out args */
+  (GDBusArgInfo **) manager_interface_add_code_out_args,
   NULL,  /* annotations */
 };
 

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -835,16 +835,17 @@ epg_manager_service_manager_add_code (EpgManagerService     *self,
                                       GDBusMethodInvocation *invocation)
 {
   g_autoptr(GError) local_error = NULL;
+  gint64 time_added = 0;
 
   const gchar *code_str;
   g_variant_get (parameters, "(&s)", &code_str);
 
-  epg_provider_add_code (self->provider, code_str, &local_error);
+  epg_provider_add_code (self->provider, code_str, &time_added, &local_error);
 
   if (local_error != NULL)
     g_dbus_method_invocation_return_gerror (invocation, local_error);
   else
-    g_dbus_method_invocation_return_value (invocation, NULL);
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(x)", time_added));
 }
 
 static void

--- a/libeos-payg/provider.h
+++ b/libeos-payg/provider.h
@@ -36,6 +36,7 @@ struct _EpgProviderInterface
 
   gboolean        (*add_code)   (EpgProvider  *self,
                                  const gchar  *code_str,
+                                 gint64       *time_added,
                                  GError      **error);
   gboolean        (*clear_code) (EpgProvider  *self,
                                  GError      **error);
@@ -61,6 +62,7 @@ struct _EpgProviderInterface
 
 gboolean        epg_provider_add_code   (EpgProvider  *self,
                                          const gchar  *code_str,
+                                         gint64       *time_added,
                                          GError      **error);
 gboolean        epg_provider_clear_code (EpgProvider  *self,
                                          GError      **error);

--- a/libeos-payg/tests/plugins/test-provider.c
+++ b/libeos-payg/tests/plugins/test-provider.c
@@ -46,6 +46,7 @@ static gboolean epg_test_provider_init_finish (GAsyncInitable  *initable,
 
 static gboolean    epg_test_provider_add_code   (EpgProvider  *provider,
                                                  const gchar  *code_str,
+                                                 gint64       *time_added,
                                                  GError      **error);
 static gboolean    epg_test_provider_clear_code (EpgProvider   *provider,
                                                  GError      **error);
@@ -214,6 +215,7 @@ epg_test_provider_constructed (GObject *object)
 static gboolean
 epg_test_provider_add_code (EpgProvider  *provider,
                             const gchar  *code_str,
+                            gint64       *time_added,
                             GError      **error)
 {
   return TRUE;


### PR DESCRIPTION
Return the amount of time added into the add_code function
of the daemon.

https://phabricator.endlessm.com/T24128