### PR TITLE
eos-payg-ctl: Understand CLOCK_BOOTTIME properties

### DIFF
--- a/debian/eos-payg-data.install
+++ b/debian/eos-payg-data.install
@@ -1,2 +1,3 @@
 usr/share/locale
 usr/bin/eos-payg-ctl
+usr/bin/get-clock-boottime

--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -20,8 +20,10 @@
 import argparse
 import contextlib
 import datetime as dt
+import time
 import posix
 import sys
+import subprocess
 from dateutil import tz
 from gi.repository import GLib, Gio
 
@@ -31,6 +33,20 @@ INTERFACE = "com.endlessm.Payg1"
 ERROR_DOMAIN = "com.endlessm.Payg1.Error"
 
 DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+
+
+def __get_utc_from_boottime(timestamp):
+    #FIXME: Replace this with time.clock_gettime(time.CLOCK_BOOTTIME)
+    # once we have Python 3.7
+    # https://phabricator.endlessm.com/T25065
+    try:
+        current_boottime = int(subprocess.check_output('get-clock-boottime'))
+    except subprocess.CalledProcessError as e:
+        print("Error calling get-clock-boottime: {}".format(e.output), file=sys.stderr, flush=True)
+        raise SystemExit(1)
+
+    timestamp_delta = timestamp - current_boottime
+    return time.time() + timestamp_delta
 
 
 def __format_utc_timestamp(timestamp):
@@ -80,7 +96,11 @@ def command_status(proxy):
     }
 
     for key, value in sorted(props.items()):
-        formatted = formatters.get(key, lambda x: x)(value)
+        if key == "ExpiryTime" or key == "RateLimitEndTime":
+            utc_timestamp = __get_utc_from_boottime(value)
+            formatted = formatters.get(key, lambda x: x)(utc_timestamp)
+        else:
+            formatted = value
         print("{:>{}}: {}".format(key, width, formatted))
 
 

--- a/eos-payg-ctl/get-clock-boottime.c
+++ b/eos-payg-ctl/get-clock-boottime.c
@@ -1,0 +1,45 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2019 Endless Mobile, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms of the
+ * GNU Lesser General Public License Version 2.1 or later (the "LGPL"), in
+ * which case the provisions of the LGPL are applicable instead of those above.
+ * If you wish to allow use of your version of this file only under the terms
+ * of the LGPL, and not to allow others to use your version of this file under
+ * the terms of the MPL, indicate your decision by deleting the provisions
+ * above and replace them with the notice and other provisions required by the
+ * LGPL. If you do not delete the provisions above, a recipient may use your
+ * version of this file under the terms of either the MPL or the LGPL.
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/timerfd.h>
+
+/* Print the current value of CLOCK_BOOTTIME in seconds */
+int main(void)
+{
+  struct timespec ts;
+  int result;
+
+  result = clock_gettime (CLOCK_BOOTTIME, &ts);
+  if (result != 0)
+    {
+      fprintf (stderr, "clock_gettime (CLOCK_BOOTTIME) failed with error %s\n", strerror (errno));
+      return 1;
+    }
+
+  printf ("%ld", ts.tv_sec);
+
+  return 0;
+}

--- a/eos-payg-ctl/meson.build
+++ b/eos-payg-ctl/meson.build
@@ -1,3 +1,13 @@
+get_clock_boottime_sources = [
+  'get-clock-boottime.c',
+]
+
+executable('get-clock-boottime',
+  get_clock_boottime_sources,
+  include_directories: root_inc,
+  install: true,
+)
+
 install_data('eos-payg-ctl',
   install_dir: bindir,
   install_mode: 'rwxr-xr-x',


### PR DESCRIPTION
Now that the "ExpiryTime" and "RateLimitEndTime" properties of
EpgProvider are in terms of CLOCK_BOOTTIME instead of being UNIX
timestamps, modify eos-payg-ctl to interpret them correctly. For now
this is implemented using a helper program until we get Python 3.7 on
the stable branch, which will give us time.CLOCK_BOOTTIME (to be used
with time.clock_gettime()).

https://phabricator.endlessm.com/T24300