### PR TITLE
eos-payg-ctl: improve conversion from BOOTTIME to human-readable timestamp

### DIFF
--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -40,15 +40,29 @@ DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 CLOCK_BOOTTIME = getattr(time, 'CLOCK_BOOTTIME', 7)
 
 
-def __format_boottime_timestamp(boottime_timestamp):
-    # Convert from CLOCK_BOOTTIME to seconds since the epoch
-    timestamp_delta = boottime_timestamp - time.clock_gettime(CLOCK_BOOTTIME)
-    utc_timestamp = time.time() + timestamp_delta
+def __make_boottime_formatter():
+    '''Returns a function which formats a timestamp in units of CLOCK_BOOTTIME
+    as a human-readable date & time. This is implemented as a higher-order
+    function so the same origin point is used for both the properties of this
+    type; otherwise, if both ExpiryTime and RateLimitEndTime are 0, they would
+    show as fractionally different times.'''
+    now_boottime = time.clock_gettime(CLOCK_BOOTTIME)
+    now_utc = time.time()
 
-    # Format that as a human-readable local time
-    expiry_utc = dt.datetime.fromtimestamp(utc_timestamp, tz=tz.tzutc())
-    expiry_local = expiry_utc.astimezone(tz.tzlocal())
-    return str(expiry_local)
+    def __format_boottime_timestamp(boottime_timestamp):
+        # Convert from CLOCK_BOOTTIME to seconds since the epoch
+        timestamp_delta = boottime_timestamp - now_boottime
+        utc_timestamp = now_utc + timestamp_delta
+
+        # Format that as a human-readable local time
+        expiry_utc = dt.datetime.fromtimestamp(utc_timestamp, tz=tz.tzutc())
+        expiry_local = expiry_utc.astimezone(tz.tzlocal())
+        return str(expiry_local)
+
+    return __format_boottime_timestamp
+
+
+__format_boottime_timestamp = __make_boottime_formatter()
 
 
 def __get_proxy(bus_address):

--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -40,13 +40,13 @@ DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 CLOCK_BOOTTIME = getattr(time, 'CLOCK_BOOTTIME', 7)
 
 
-def __get_utc_from_boottime(timestamp):
-    timestamp_delta = timestamp - time.clock_gettime(CLOCK_BOOTTIME)
-    return time.time() + timestamp_delta
+def __format_boottime_timestamp(boottime_timestamp):
+    # Convert from CLOCK_BOOTTIME to seconds since the epoch
+    timestamp_delta = boottime_timestamp - time.clock_gettime(CLOCK_BOOTTIME)
+    utc_timestamp = time.time() + timestamp_delta
 
-
-def __format_utc_timestamp(timestamp):
-    expiry_utc = dt.datetime.fromtimestamp(timestamp, tz=tz.tzutc())
+    # Format that as a human-readable local time
+    expiry_utc = dt.datetime.fromtimestamp(utc_timestamp, tz=tz.tzutc())
     expiry_local = expiry_utc.astimezone(tz.tzlocal())
     return str(expiry_local)
 
@@ -87,16 +87,12 @@ def command_status(proxy):
 
     width = max(map(len, props), default=0)
     formatters = {
-        "ExpiryTime": __format_utc_timestamp,
-        "RateLimitEndTime": __format_utc_timestamp,
+        "ExpiryTime": __format_boottime_timestamp,
+        "RateLimitEndTime": __format_boottime_timestamp,
     }
 
     for key, value in sorted(props.items()):
-        if key == "ExpiryTime" or key == "RateLimitEndTime":
-            utc_timestamp = __get_utc_from_boottime(value)
-            formatted = formatters.get(key, lambda x: x)(utc_timestamp)
-        else:
-            formatted = value
+        formatted = formatters.get(key, lambda x: x)(value)
         print("{:>{}}: {}".format(key, width, formatted))
 
 

--- a/eos-payg-ctl/eos-payg-ctl
+++ b/eos-payg-ctl/eos-payg-ctl
@@ -33,12 +33,15 @@ ERROR_DOMAIN = "com.endlessm.Payg1.Error"
 
 DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
+# Python 3.5 does not define time.CLOCK_BOOTTIME. linux/time.h has:
+#     #define CLOCK_BOOTTIME 7
+# FIXME: use time.CLOCK_BOOTTIME directly once we can have Python 3.7.
+# https://phabricator.endlessm.com/T25065
+CLOCK_BOOTTIME = getattr(time, 'CLOCK_BOOTTIME', 7)
+
 
 def __get_utc_from_boottime(timestamp):
-    #FIXME: Replace this with time.clock_gettime(time.CLOCK_BOOTTIME)
-    # once we have Python 3.7
-    # https://phabricator.endlessm.com/T25065
-    timestamp_delta = timestamp - time.clock_gettime(7)
+    timestamp_delta = timestamp - time.clock_gettime(CLOCK_BOOTTIME)
     return time.time() + timestamp_delta
 
 


### PR DESCRIPTION
Some stylistic stuff, and one very minor improvement to use the same offset for the two properties, rather than introducing fractional differences. All absolutely inessential.

https://phabricator.endlessm.com/T24300