### PR TITLE
manager: Fix logic for migrating state files

### DIFF
--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -1311,7 +1311,10 @@ file_load_delete_cb (GObject      *source_object,
     }
 
   if (error == NULL)
-    epg_multi_task_return_boolean (task, TRUE);
+    {
+      epg_multi_task_return_boolean (task, TRUE);
+      return;
+    }
 
   epg_multi_task_return_error (task, G_STRFUNC, g_error_copy (error));
 }


### PR DESCRIPTION
When the EpgManager is migrating the state files, and specifically
deleting the "expiry-time" file so the "clock-time" and "expiry-seconds"
files can be used instead, there was a logical error in the callback for
the file deletion, file_load_delete_cb(). After calling
epg_multi_task_return_boolean() on the success code path, it also called
epg_multi_task_return_error() resulting in assertion failures:

Jan 14 12:23:47 endless eos-paygd1[728]: g_error_copy: assertion 'error
!= NULL' failed
Jan 14 12:23:47 endless eos-paygd1[728]: epg_multi_task_return_error:
assertion 'error != NULL' failed

This also seems to have the effect of locking the computer (putting it
back in the state where a payg code is required to use it). So fix the
logic so that already provisioned computers that upgrade to 3.5.5 aren't
incorrectly put in a locked state. It's unclear why I only saw this bug
once during the QA for T24300.

https://phabricator.endlessm.com/T25138