### PR TITLE
manager: Save state after migrating state files

### DIFF
--- a/libeos-payg/tests/manager.c
+++ b/libeos-payg/tests/manager.c
@@ -440,6 +440,8 @@ test_manager_save_error (Fixture *fixture,
 
   /* Sabotage any future attempts to save state. */
   remove_path (fixture->key_path);
+  remove_path (fixture->clock_time_path);
+  remove_path (fixture->expiry_seconds_path);
   remove_path (fixture->tmp_path);
 
   if (apply_code)


### PR DESCRIPTION
We want the EpgManager to save state to the disk upon startup, because
otherwise an unclean shutdown would leave us in the wrong state upon the
next boot. However the call to epg_manager_save_state_async() is in
file_load_cb() in an if block that only gets executed if the two state
files used to store the expiry time have been loaded, which means it
doesn't get executed if we're migrating from the old single state file
(migrating from expiry-time to clock-time and expiry-seconds).

So move the save_state_async() call to set_expiry_time() so that it
happens every time the expiry time is updated. This applies in the
migration case above but also a few other code paths, such as when
there's an error loading the state data. This commit also removes the
save_state_async() call in add_code(), because I think the only time the
state save is necessary is when the added code affected the expiry time.

https://phabricator.endlessm.com/T25138