### PR TITLE
eos-payg-csv: ensure test files available for OBS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
 Description: Pay As You Go Code Generator
- This package contains a utility to generate pay as you go codes.
+ This package contains utilities to generate pay as you go codes.
 
 Package: eos-payg-generate-tests
 Section: misc
@@ -60,9 +60,9 @@ Depends:
  ${python3:Depends},
  ${shlibs:Depends},
 Description: Pay As You Go Code Generator - tests
- This package contains a utility to generate pay as you go codes.
+ This package contains utilities to generate pay as you go codes.
  .
- This package contains unit tests for the utility.
+ This package contains unit tests for the utilities.
 
 Package: libeos-payg-1-dev
 Section: misc

--- a/debian/eos-payg-generate-tests.install
+++ b/debian/eos-payg-generate-tests.install
@@ -1,2 +1,4 @@
+usr/lib/*/installed-tests/eos-payg-csv
 usr/lib/*/installed-tests/eos-payg-generate-1
+usr/share/installed-tests/eos-payg-csv
 usr/share/installed-tests/eos-payg-generate-1

--- a/debian/eos-payg-generate.install
+++ b/debian/eos-payg-generate.install
@@ -1,2 +1,3 @@
+usr/bin/eos-payg-csv
 usr/bin/eos-payg-generate-1
 usr/share/man/man8/eos-payg-generate.8*

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,13 @@ override_dh_auto_configure:
 		-Ddefault_library=static \
 		$(NULL)
 
+# Remove LD_PRELOAD so we don't run with fakeroot. libgsystemservice's tests
+# use GTestDBus, which spawns a new dbus-daemon, which tries to raise its file
+# descriptor limit to 65536 if its uid appears to be 0, which fails because it
+# is not *actually* root. (This workaround is taken from the GLib packaging.)
+override_dh_auto_test:
+	env -u LD_PRELOAD dh_auto_test
+
 # Don't start the services on install
 override_dh_systemd_start:
 	dh_systemd_start -peos-paygd --no-start eos-paygd.service

--- a/debian/tests/gnome-desktop-testing
+++ b/debian/tests/gnome-desktop-testing
@@ -24,6 +24,7 @@ exec 2>&1
 exec gnome-desktop-testing-runner \
 	eos-paygd-1 \
 	eos-payg-generate-1 \
+	eos-payg-csv \
 	libeos-payg-1 \
 	libeos-payg-codes-1 \
 	--

--- a/eos-payg-csv/tests/meson.build
+++ b/eos-payg-csv/tests/meson.build
@@ -37,7 +37,7 @@ foreach program: test_programs
     )
     install_data(
       main,
-      files('short-key.csv', 'valid.csv', 'wrong-columns.csv'),
+      files('short-key.csv', 'valid-2-keys-dupes.csv', 'wrong-columns.csv'),
       install_dir: installed_tests_metadir,
       install_mode: 'rw-r--r--',
     )


### PR DESCRIPTION
Currently, the OBS builds are broken (though Jenkins builds are not)
because OBS performs the installed tests and does not see the required
data files.

This ensures the test files are available in that case.

https://phabricator.endlessm.com/T25205