### PR TITLE
.service: remove PrivateDevices, add DevicePolicy

### DIFF
--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -12,13 +12,13 @@ User=@DAEMON_USER@
 
 # Sandboxing
 CapabilityBoundingSet=
+DevicePolicy=closed
 Environment=GIO_USE_VFS=local
 Environment=GVFS_DISABLE_FUSE=1
 Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1
 Environment=GSETTINGS_BACKEND=memory
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
-PrivateDevices=yes
 PrivateNetwork=yes
 PrivateTmp=yes
 PrivateUsers=yes


### PR DESCRIPTION
An out-of-tree provider needs to be able to enumerate the contents of
/dev; PrivateDevices=yes causes a minimal /dev to be mounted for the
executed process, which means the important devices are not visible to
eos-paygd.

PrivateDevices=true implies a number of other restrictions:

* @raw-io system calls are blocked
* CAP_MKNOD and CAP_SYS_RAWIO are removed from CapabilityBoundingSet
* DevicePolicy=closed is set

The first two restrictions are already by other lines in this file; add
DevicePolicy=closed. (The out-of-tree provider opens the relevant device
using UDisks, essentially circumventing this restriction, but in a
controlled way.)

https://phabricator.endlessm.com/T24134