### PR TITLE
service: Fix a seg fault on shutdown

### DIFF
--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -126,7 +126,14 @@ epg_service_dispose (GObject *object)
 
   g_clear_object (&self->manager_service);
   g_clear_object (&self->provider);
-  g_clear_object (&self->source);
+
+  if (self->source != NULL)
+    {
+      g_source_destroy (self->source);
+      g_source_unref (self->source);
+      self->source = NULL;
+    }
+
   g_clear_pointer (&self->config_file_path, g_free);
 
   /* Chain up to the parent class */


### PR DESCRIPTION
I tried to use g_clear_object() on a GSource pointer, but those are not
objects. Use g_source_destroy() followed by g_source_unref() instead to
avoid a seg fault on shutdown.

https://phabricator.endlessm.com/T24501