### PR TITLE
eos-payg: Add a prefix and suffix property of the codes

### DIFF
--- a/libeos-payg/manager-interface.h
+++ b/libeos-payg/manager-interface.h
@@ -131,12 +131,32 @@ static const GDBusPropertyInfo manager_interface_code_format =
   NULL,  /* annotations */
 };
 
+static const GDBusPropertyInfo manager_interface_code_format_prefix =
+{
+  -1,  /* ref count */
+  (gchar *) "CodeFormatPrefix",
+  (gchar *) "s",
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
+static const GDBusPropertyInfo manager_interface_code_format_suffix =
+{
+  -1,  /* ref count */
+  (gchar *) "CodeFormatSuffix",
+  (gchar *) "s",
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
 static const GDBusPropertyInfo *manager_interface_properties[] =
 {
   &manager_interface_expiry_time,
   &manager_interface_enabled,
   &manager_interface_rate_limit_end_time,
   &manager_interface_code_format,
+  &manager_interface_code_format_prefix,
+  &manager_interface_code_format_suffix,
   NULL,
 };
 

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -115,6 +115,20 @@ static GVariant *epg_manager_service_manager_get_code_format (EpgManagerService 
                                                               const gchar           *property_name,
                                                               GDBusMethodInvocation *invocation);
 
+static GVariant *epg_manager_service_manager_get_code_format_prefix (EpgManagerService     *self,
+                                                                     GDBusConnection       *connection,
+                                                                     const gchar           *sender,
+                                                                     const gchar           *interface_name,
+                                                                     const gchar           *property_name,
+                                                                     GDBusMethodInvocation *invocation);
+
+static GVariant *epg_manager_service_manager_get_code_format_suffix (EpgManagerService     *self,
+                                                                     GDBusConnection       *connection,
+                                                                     const gchar           *sender,
+                                                                     const gchar           *interface_name,
+                                                                     const gchar           *property_name,
+                                                                     GDBusMethodInvocation *invocation);
+
 static void expired_cb (EpgProvider *provider,
                         gpointer     user_data);
 static void notify_cb  (GObject    *obj,
@@ -596,6 +610,10 @@ manager_properties[] =
       epg_manager_service_manager_get_rate_limit_end_time, NULL  /* read-only */ },
     { "com.endlessm.Payg1", "CodeFormat", "code-format",
       epg_manager_service_manager_get_code_format, NULL  /* read-only */ },
+    { "com.endlessm.Payg1", "CodeFormatPrefix", "code-format-prefix",
+      epg_manager_service_manager_get_code_format_prefix, NULL  /* read-only */ },
+    { "com.endlessm.Payg1", "CodeFormatSuffix", "code-format-suffix",
+      epg_manager_service_manager_get_code_format_suffix, NULL  /* read-only */ },
   };
 
 G_STATIC_ASSERT (G_N_ELEMENTS (manager_properties) ==
@@ -825,6 +843,28 @@ epg_manager_service_manager_get_code_format (EpgManagerService     *self,
                                              GDBusMethodInvocation *invocation)
 {
   return g_variant_new_string (epg_provider_get_code_format (self->provider));
+}
+
+static GVariant *
+epg_manager_service_manager_get_code_format_prefix (EpgManagerService     *self,
+                                                    GDBusConnection       *connection,
+                                                    const gchar           *sender,
+                                                    const gchar           *interface_name,
+                                                    const gchar           *property_name,
+                                                    GDBusMethodInvocation *invocation)
+{
+  return g_variant_new_string (epg_provider_get_code_format_prefix (self->provider));
+}
+
+static GVariant *
+epg_manager_service_manager_get_code_format_suffix (EpgManagerService     *self,
+                                                    GDBusConnection       *connection,
+                                                    const gchar           *sender,
+                                                    const gchar           *interface_name,
+                                                    const gchar           *property_name,
+                                                    GDBusMethodInvocation *invocation)
+{
+  return g_variant_new_string (epg_provider_get_code_format_suffix (self->provider));
 }
 
 static void

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -183,6 +183,8 @@ typedef enum
   PROP_ENABLED,
   PROP_RATE_LIMIT_END_TIME,
   PROP_CODE_FORMAT,
+  PROP_CODE_FORMAT_PREFIX,
+  PROP_CODE_FORMAT_SUFFIX,
   PROP_CLOCK,
 } EpgManagerProperty;
 
@@ -208,6 +210,8 @@ epg_manager_class_init (EpgManagerClass *klass)
   g_object_class_override_property (object_class, PROP_ENABLED, "enabled");
   g_object_class_override_property (object_class, PROP_RATE_LIMIT_END_TIME, "rate-limit-end-time");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT, "code-format");
+  g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
+  g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
 
   /**
@@ -278,6 +282,8 @@ epg_manager_provider_iface_init (gpointer g_iface,
   iface->get_clock = epg_manager_get_clock;
 
   iface->code_format = "^[0-9]{8}$";
+  iface->code_format_prefix = "";
+  iface->code_format_suffix = "";
 }
 
 static void
@@ -375,6 +381,12 @@ epg_manager_get_property (GObject    *object,
     case PROP_CODE_FORMAT:
       g_value_set_static_string (value, epg_provider_get_code_format (provider));
       break;
+    case PROP_CODE_FORMAT_PREFIX:
+      g_value_set_static_string (value, epg_provider_get_code_format_prefix (provider));
+      break;
+    case PROP_CODE_FORMAT_SUFFIX:
+      g_value_set_static_string (value, epg_provider_get_code_format_suffix (provider));
+      break;
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
@@ -396,6 +408,14 @@ epg_manager_set_property (GObject      *object,
     case PROP_EXPIRY_TIME:
     case PROP_RATE_LIMIT_END_TIME:
     case PROP_CODE_FORMAT:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_CODE_FORMAT_PREFIX:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_CODE_FORMAT_SUFFIX:
       /* Read only. */
       g_assert_not_reached ();
       break;

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -121,6 +121,40 @@ epg_provider_default_init (EpgProviderInterface *iface)
   g_object_interface_install_property (iface, pspec);
 
   /**
+   * EpgProvider:code-format-prefix:
+   *
+   * A gchar representing the expected prefix of a format of codes expected by
+   * epg_provider_add_code() on this provider.
+   *
+   * This property is constant once the provider is initialized.
+   *
+   * Since: 0.2.2
+   */
+  pspec =
+      g_param_spec_string ("code-format-prefix", "Code Format Prefix",
+                           "The prefix of the format code expected by this provider",
+                           "",
+                           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+  g_object_interface_install_property (iface, pspec);
+
+  /**
+   * EpgProvider:code-format:
+   *
+   * A gchar representing the expected suffix of a format of codes expected by
+   * epg_provider_add_code() on this provider.
+   *
+   * This property is constant once the provider is initialized.
+   *
+   * Since: 0.2.2
+   */
+  pspec =
+      g_param_spec_string ("code-format-suffix", "Code Format Suffix",
+                           "The suffix of the format code expected by this provider",
+                           "",
+                           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+  g_object_interface_install_property (iface, pspec);
+
+  /**
    * EpgProvider:clock:
    *
    * Clock used to get the time and create timeout #GSource objects.
@@ -385,6 +419,48 @@ epg_provider_get_code_format (EpgProvider *self)
   g_assert (iface->code_format != NULL);
 
   return iface->code_format;
+}
+
+/**
+ * epg_provider_get_code_format_prefix:
+ * @self: a #EpgProvider
+ *
+ * Get the value of #EpgProvider:code-format-prefix
+ *
+ * Returns: the prefix of the code-format expected by this provider
+ * Since: 0.2.2
+ */
+const gchar *
+epg_provider_get_code_format_prefix (EpgProvider *self)
+{
+  g_return_val_if_fail (EPG_IS_PROVIDER (self), NULL);
+
+  EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->code_format_prefix == NULL, "");
+
+  return iface->code_format_prefix;
+}
+
+/**
+ * epg_provider_get_code_format_suffix:
+ * @self: a #EpgProvider
+ *
+ * Get the value of #EpgProvider:code-format-suffix
+ *
+ * Returns: the suffix of the code-format expected by this provider
+ * Since: 0.2.2
+ */
+const gchar *
+epg_provider_get_code_format_suffix (EpgProvider *self)
+{
+  g_return_val_if_fail (EPG_IS_PROVIDER (self), NULL);
+
+  EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
+
+  g_return_val_if_fail (iface->code_format_suffix == NULL, "");
+
+  return iface->code_format_suffix;
 }
 
 /**

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -437,9 +437,10 @@ epg_provider_get_code_format_prefix (EpgProvider *self)
 
   EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
 
-  g_return_val_if_fail (iface->code_format_prefix != NULL, "");
+  if (iface->code_format_prefix != NULL)
+    return iface->code_format_prefix;
 
-  return iface->code_format_prefix;
+  return "";
 }
 
 /**
@@ -458,9 +459,10 @@ epg_provider_get_code_format_suffix (EpgProvider *self)
 
   EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
 
-  g_return_val_if_fail (iface->code_format_suffix != NULL, "");
+  if (iface->code_format_suffix != NULL)
+    return iface->code_format_suffix;
 
-  return iface->code_format_suffix;
+  return "";
 }
 
 /**

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -437,7 +437,7 @@ epg_provider_get_code_format_prefix (EpgProvider *self)
 
   EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
 
-  g_return_val_if_fail (iface->code_format_prefix == NULL, "");
+  g_return_val_if_fail (iface->code_format_prefix != NULL, "");
 
   return iface->code_format_prefix;
 }
@@ -458,7 +458,7 @@ epg_provider_get_code_format_suffix (EpgProvider *self)
 
   EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
 
-  g_return_val_if_fail (iface->code_format_suffix == NULL, "");
+  g_return_val_if_fail (iface->code_format_suffix != NULL, "");
 
   return iface->code_format_suffix;
 }

--- a/libeos-payg/provider.h
+++ b/libeos-payg/provider.h
@@ -58,6 +58,8 @@ struct _EpgProviderInterface
   EpgClock       *(*get_clock)               (EpgProvider *self);
 
   const gchar *     code_format;
+  const gchar *     code_format_prefix;
+  const gchar *     code_format_suffix;
 };
 
 gboolean        epg_provider_add_code   (EpgProvider  *self,
@@ -82,6 +84,8 @@ guint64         epg_provider_get_expiry_time         (EpgProvider *self);
 gboolean        epg_provider_get_enabled             (EpgProvider *self);
 guint64         epg_provider_get_rate_limit_end_time (EpgProvider *self);
 const gchar *   epg_provider_get_code_format         (EpgProvider *self);
+const gchar *   epg_provider_get_code_format_prefix  (EpgProvider *self);
+const gchar *   epg_provider_get_code_format_suffix  (EpgProvider *self);
 EpgClock *      epg_provider_get_clock               (EpgProvider *self);
 
 G_END_DECLS

--- a/libeos-payg/tests/manager.c
+++ b/libeos-payg/tests/manager.c
@@ -274,6 +274,36 @@ get_code_format (Fixture *fixture)
   return g_steal_pointer (&regex);
 }
 
+/* test_code_format_prefix:
+ *
+ * Tests that the :code-format-prefix is properly returned.
+ */
+static void
+test_manager_code_format_prefix (Fixture *fixture,
+                                 gconstpointer data)
+{
+  manager_new (fixture);
+
+  const gchar *code_format_prefix = epg_provider_get_code_format_prefix (fixture->provider);
+
+  g_assert_cmpstr (code_format_prefix, ==, "");
+}
+
+/* test_code_format_suffix:
+ *
+ * Tests that the :code-format-suffix is properly returned.
+ */
+static void
+test_manager_code_format_suffix (Fixture *fixture,
+                                 gconstpointer data)
+{
+  manager_new (fixture);
+
+  const gchar *code_format_suffix = epg_provider_get_code_format_suffix (fixture->provider);
+
+  g_assert_cmpstr (code_format_suffix, ==, "");
+}
+
 /* test_manager_code_format_matches:
  * @data: const gchar *
  *
@@ -844,6 +874,8 @@ main (int    argc,
   T ("/manager/extend-expiry", test_manager_extend_expiry, NULL);
   T ("/manager/add-save-reload", test_manager_add_save_reload, NULL);
   T ("/manager/add-infinite", test_manager_add_infinite_code, NULL);
+  T ("/manager/get-code-format-prefix", test_manager_code_format_prefix, NULL);
+  T ("/manager/get-code-format-suffix", test_manager_code_format_suffix, NULL);
   T ("/manager/error/malformed", test_manager_error_malformed, NULL);
   T ("/manager/error/reused", test_manager_error_reused, NULL);
   T ("/manager/error/rate-limit", test_manager_error_rate_limit, NULL);

--- a/libeos-payg/tests/plugins/test-provider.c
+++ b/libeos-payg/tests/plugins/test-provider.c
@@ -76,6 +76,8 @@ typedef enum
   PROP_ENABLED,
   PROP_RATE_LIMIT_END_TIME,
   PROP_CODE_FORMAT,
+  PROP_CODE_FORMAT_PREFIX,
+  PROP_CODE_FORMAT_SUFFIX,
   PROP_CLOCK,
 } EpgTestProviderProperty;
 
@@ -100,6 +102,8 @@ epg_test_provider_class_init (EpgTestProviderClass *klass)
   g_object_class_override_property (object_class, PROP_ENABLED, "enabled");
   g_object_class_override_property (object_class, PROP_RATE_LIMIT_END_TIME, "rate-limit-end-time");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT, "code-format");
+  g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
+  g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
 }
 
@@ -128,6 +132,8 @@ epg_test_provider_provider_iface_init (gpointer g_iface,
   iface->get_rate_limit_end_time = epg_test_provider_get_rate_limit_end_time;
   iface->get_clock = epg_test_provider_get_clock;
   iface->code_format = "";
+  iface->code_format_prefix = "";
+  iface->code_format_suffix = "";
 }
 
 static void
@@ -158,6 +164,12 @@ epg_test_provider_get_property (GObject    *object,
     case PROP_CODE_FORMAT:
       g_value_set_static_string (value, epg_provider_get_code_format (provider));
       break;
+    case PROP_CODE_FORMAT_PREFIX:
+      g_value_set_static_string (value, epg_provider_get_code_format_prefix (provider));
+      break;
+    case PROP_CODE_FORMAT_SUFFIX:
+      g_value_set_static_string (value, epg_provider_get_code_format_suffix (provider));
+      break;
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
@@ -180,6 +192,14 @@ epg_test_provider_set_property (GObject      *object,
     case PROP_EXPIRY_TIME:
     case PROP_RATE_LIMIT_END_TIME:
     case PROP_CODE_FORMAT:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_CODE_FORMAT_PREFIX:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_CODE_FORMAT_SUFFIX:
       /* Read only. */
       g_assert_not_reached ();
       break;


### PR DESCRIPTION
Add a property that returns the prefix and sufix of the codes used,
making the interface of code insertion for user-friendly.

https://phabricator.endlessm.com/T25987