### PR TITLE
Error out if PAYG is not enabled when it should be

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  meson,
  python3-dbusmock,
  dracut,
+ libefivar-dev,
 
 Package: eos-paygd
 Section: misc

--- a/libeos-payg/meson.build
+++ b/libeos-payg/meson.build
@@ -35,6 +35,7 @@ libeos_payg_deps = [
   dependency('glib-2.0', version: '>= 2.54'),
   dependency('gobject-2.0', version: '>= 2.54'),
   dependency('libpeas-1.0'),
+  dependency('efivar'),
   libeos_payg_codes_dep,
   libgsystemservice_dep,
 ]

--- a/libeos-payg/service.h
+++ b/libeos-payg/service.h
@@ -25,6 +25,21 @@
 
 G_BEGIN_DECLS
 
+/**
+ * EpgServiceError:
+ * @EPG_SERVICE_ERROR_NO_PROVIDER: No PAYG provider was found to be enabled,
+ *                                 despite PAYG being active.
+ *
+ * Error codes returned by #EpgService
+ */
+typedef enum {
+  EPG_SERVICE_ERROR_NO_PROVIDER,
+  EPG_SERVICE_ERROR_LAST = EPG_SERVICE_ERROR_NO_PROVIDER, /*< skip >*/
+} EpgServiceError;
+
+#define EPG_SERVICE_ERROR (epg_service_error_quark ())
+GQuark epg_service_error_quark (void);
+
 #define EPG_TYPE_SERVICE epg_service_get_type ()
 G_DECLARE_FINAL_TYPE (EpgService, epg_service, EPG, SERVICE, GssService)
 


### PR DESCRIPTION
Currently in epg_service_secure_init_sync() we have "g_assert (provider
!= NULL)" which means that eos-paygd hits an assertion failure in case
it's running on a non-PAYG system, or in case it's running on a PAYG
system using the filesystem to store state. In the latter case the
provider is only found to be enabled after the root pivot, and the
secure init happens before the root pivot.

This commit removes the assertion, and instead checks if no providers
have been found after the root pivot. If none were found and the
EOSPAYG_active EFI variable is set, we error out and force a poweroff
after 10 minutes. Otherwise the user could disable PAYG by zeroing out
the state data. The EFI variable check ensures that this security
measure only applies to Phase 4 systems, which will set EOSPAYG_active
during PAYG provisioning. On Phase 1 or 2 systems, we try falling back
to Endless PAYG and failing that eos-paygd gracefully exits.

https://phabricator.endlessm.com/T27581