### PR TITLE
service: Don't seg fault on shutdown w/ no provider

### DIFF
--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -533,22 +533,26 @@ static void
 epg_service_shutdown (GssService *service)
 {
   EpgService *self = EPG_SERVICE (service);
-  g_autoptr(GError) local_error = NULL;
 
-  /* Save the provider’s state. */
-  g_autoptr(GAsyncResult) result = NULL;
-  epg_provider_shutdown_async (self->provider, NULL, async_result_cb, &result);
-
-  while (result == NULL)
-    g_main_context_iteration (NULL, TRUE);
-
-  if (!epg_provider_shutdown_finish (self->provider, result, &local_error))
+  if (self->provider != NULL)
     {
-      g_warning ("Error shutting down provider: %s", local_error->message);
-      g_clear_error (&local_error);
-    }
+      g_autoptr(GAsyncResult) result = NULL;
+      g_autoptr(GError) local_error = NULL;
 
-  epg_manager_service_unregister (self->manager_service);
+      /* Save the provider’s state. */
+      epg_provider_shutdown_async (self->provider, NULL, async_result_cb, &result);
+
+      while (result == NULL)
+        g_main_context_iteration (NULL, TRUE);
+
+      if (!epg_provider_shutdown_finish (self->provider, result, &local_error))
+        {
+          g_warning ("Error shutting down provider: %s", local_error->message);
+          g_clear_error (&local_error);
+        }
+
+      epg_manager_service_unregister (self->manager_service);
+    }
 }
 
 /**


### PR DESCRIPTION
Before commit 97d4edf36, the provider field of an EpgService object was
always non-NULL after epg_service_startup_async() completed, since an
EpgManager was used as a fallback if other providers weren't enabled,
regardless of whether or not Endless PAYG was enabled. But after commit
97d4edf36, we may complete startup with no provider if none were
enabled. So add a check to epg_service_shutdown() so we don't try to use
a NULL provider object, which I believe is causing a seg fault.

Since provider_notify_enabled_cb() is already called by
epg_service_startup_complete() and there we exit the service if the
provider is disabled, we could remove the epg_provider_get_enabled()
check in manager_new_cb() and avoid the need for this patch. But perhaps
leaving in the early enabled check is better, so we don't do superfluous
initialization of a disabled provider (especially since the whole system
goes down if eos-paygd goes down).

https://phabricator.endlessm.com/T27037