### PR TITLE
service: Fix a g_debug missing format parameters

### DIFF
--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -329,7 +329,7 @@ epg_service_secure_init_sync (EpgService   *self,
    * pivot.
    */
   if (provider == NULL)
-    g_debug ("%s: No enabled providers found pre-root-pivot");
+    g_debug ("%s: No enabled providers found pre-root-pivot", G_STRFUNC);
   else
     epg_service_set_provider (self, g_steal_pointer (&provider));
 }


### PR DESCRIPTION
Fix a g_debug() message which has a %s but no argument provided for it,
which causes a seg fault when a payg image is booted with no providers
enabled.

It's frightening that any crashing bug in eos-paygd brings the whole
system down. I filed this ticket about doing an audit:
https://phabricator.endlessm.com/T27681

https://phabricator.endlessm.com/T27581