### PR TITLE
meson.build: Change warning_level to 3 and werror to true

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,9 @@ test_args = [
   '-Wcast-align',
   '-Wclobbered',
   '-Wno-declaration-after-statement',
+  # FIXME: Remove this -Wno-error after updating libpeas to 1.24 (libpeas
+  # header files mention GParameter)
+  '-Wno-error=deprecated-declarations',
   '-Wduplicated-branches',
   '-Wduplicated-cond',
   '-Wempty-body',

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,8 @@ project('eos-payg','c',
     # static.
     'default_library=static',
     'c_std=gnu11',
-    'warning_level=2',
+    'warning_level=3',
+    'werror=true',
   ],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -113,6 +113,9 @@ test_args = [
 cc = meson.get_compiler('c')
 add_project_arguments(cc.get_supported_arguments(test_args), language: 'c')
 
+# Apply -Wno-pedantic to subprojects too
+add_global_arguments(cc.get_supported_arguments(['-Wno-pedantic']), language: 'c')
+
 want_tests = get_option('tests')
 enable_installed_tests = get_option('installed_tests')
 test_template = files('template.test.in')


### PR DESCRIPTION
Increase the warning level to 3. Meson decides which -W cflags that
translates to. And set werror to true, which translates to -Werror.

The impetus for this is that any bugs in eos-paygd have potentially
severe impact (e.g. not enforce PAYG or crash and temporarily brick a
computer).