### PR TITLE
eos-paygd: Make watchdog_fd static

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -35,7 +35,7 @@
 #define FATAL_SIGNAL_EXIT_CODE 254
 #define WATCHDOG_FAILURE_EXIT_CODE 253
 
-int watchdog_fd = -1;
+static int watchdog_fd = -1;
 
 /* Ping the watchdog periodically as long as eos-paygd is running. */
 static gboolean


### PR DESCRIPTION
There's no reason for this variable to be visible outside this file.

https://phabricator.endlessm.com/T27051