### PR TITLE
eos-paygd: Change DevicePolicy to auto

### DIFF
--- a/eos-paygd/eos-paygd-2.service.in
+++ b/eos-paygd/eos-paygd-2.service.in
@@ -27,7 +27,8 @@ KillMode=none
 SendSIGKILL=no
 
 # Sandboxing
-DevicePolicy=closed
+# We need access to /dev/watchdog and /dev/mmcblkxboot0 at least
+DevicePolicy=auto
 Environment=GIO_USE_VFS=local
 Environment=GVFS_DISABLE_FUSE=1
 Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1

--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -18,7 +18,8 @@ KillMode=none
 SendSIGKILL=no
 
 # Sandboxing
-DevicePolicy=closed
+# We might need access to /dev/mmcblkxboot0
+DevicePolicy=auto
 Environment=GIO_USE_VFS=local
 Environment=GVFS_DISABLE_FUSE=1
 Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1


### PR DESCRIPTION
Currently in eos-paygd{-2}.service.in we have DevicePolicy=closed, which
means with a few exceptions that eos-paygd can't access the device files
in /dev/. But we need to be able to access /dev/mmcblkxboot0, and since
we can't make an assumption about the value of x (usually 0), we can't
use DeviceAllow= to make an exception for that boot partition device. So
change DevicePolicy to auto, which means we're allowed access to all
devices as long as we don't use DeviceAllow. In the case of
eos-paygd-2.service (the initramfs service) we also need access to
/dev/watchdog. Currently payg images fail to boot successfully with the
error "eos-paygd could not open /dev/watchdog: Operation not permitted".

I tested this fix in a VM, albeit with an eos image not a payg one.

https://phabricator.endlessm.com/T27051