### PR TITLE
eos-paygd: Don't exit after opening the watchdog

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -290,5 +290,13 @@ main (int   argc,
     ret = 0;
 
   allow_writing_to_boot_partition (FALSE);
+
+  if (ret == 0 && !backward_compat_mode)
+    {
+      /* Continue to ping the watchdog indefinitely */
+      while (TRUE)
+        g_main_context_iteration (NULL, TRUE);
+    }
+
   return ret;
 }


### PR DESCRIPTION
Once eos-paygd opens /dev/watchdog, we have to keep pinging it as long
as the system is running to prevent a forced poweroff by the kernel.
Currently EpgService exits with no error set in case no provider is
enabled and the EFI variable EOSPAYG_active is not set (meaning either
the system is not Phase 4 PAYG, or it has been paid off, or it has not
been provisioned yet). So in that case, continue to iterate the main
loop forever so we keep pinging the watchdog. The topic of having
eos-paygd exit when the computer is shutting down is covered by
https://phabricator.endlessm.com/T27718

Since the provisioning process currently requires a reboot, there's no
danger that eos-paygd will remain in this ping-only state on a PAYG
enabled machine.

https://phabricator.endlessm.com/T27051