### PR TITLE
eos-paygd: chroot before the root pivot

### DIFF
--- a/eos-paygd/eos-paygd-2.service.in
+++ b/eos-paygd/eos-paygd-2.service.in
@@ -36,17 +36,21 @@ Environment=GSETTINGS_BACKEND=memory
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 PrivateNetwork=yes
-PrivateTmp=yes
+# Commented out sandboxing settings below this point that start with a -
+# have been tested to break our chroot() and are left here to save future
+# generations from accidentally turning them on.
+#-PrivateTmp=yes
 # We need PrivateUsers=no to be able to chown /var/lib/eos-payg
 PrivateUsers=no
-ProtectControlGroups=yes
-ProtectHome=yes
-ProtectKernelModules=yes
+#-ProtectControlGroups=yes
+#-ProtectHome=yes
+#-ProtectKernelModules=yes
 # ProtectKernelTunables=yes would keep us from writing to /sys/block/mmcblk0boot0/force_ro
 ProtectKernelTunables=no
-ProtectSystem=full
+#-ProtectSystem=full
 RestrictAddressFamilies=AF_UNIX
 RestrictRealtime=yes
 SystemCallErrorNumber=EPERM
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @resources
+# @mount must not be in the filter, as that group of syscalls includes chroot()
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @obsolete @raw-io @resources
 SystemCallArchitectures=native


### PR DESCRIPTION
We need to chroot into /sysroot before the root pivot occurs so
the dbus socket (among many other things) is visible to us. But
we have to do that *after* telling system it's ok to proceed with
the pivot, and start deleting the root of our current directory
hierarchy.

Do this with a special sd_notify variant that lets us chroot
away from the space the sd notification socket lives in before
sending the notification.

Also, to make this chroot possible, relax a bunch of sandboxing
settings.

https://phabricator.endlessm.com/T27035