### PR TITLE
WIP: fix Meson warnings

### DIFF
--- a/eos-payg-csv/tests/meson.build
+++ b/eos-payg-csv/tests/meson.build
@@ -1,5 +1,5 @@
-py3_mod = import('python3')
-py3 = py3_mod.find_python()
+python_mod = import('python')
+py3 = python_mod.find_installation('python3')
 
 envs = test_env + [
   'G_TEST_SRCDIR=' + meson.current_source_dir(),

--- a/eos-payg-generate/tests/meson.build
+++ b/eos-payg-generate/tests/meson.build
@@ -1,5 +1,5 @@
-py3_mod = import('python3')
-py3 = py3_mod.find_python()
+python_mod = import('python')
+py3 = python_mod.find_installation('python3')
 
 envs = test_env + [
   'G_TEST_SRCDIR=' + meson.current_source_dir(),

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('eos-payg','c',
   version: '0.2.2',
-  meson_version: '>= 0.47.0',
+  meson_version: '>= 0.50.0',
   license: 'MPL-2.0 or LGPLv2.1+',
   default_options: [
     # We want all internal libraries, including libgsystemservice, to be


### PR DESCRIPTION
I spotted these while doing a round of translations on https://phabricator.endlessm.com/T27764.

TODO:

- [ ] Verify that the tests pass. I've only run `meson _build`.
- [ ] Fix the remaining warning below:

```
manual-provision-payg/meson.build:1: WARNING: Custom target input 'testsuite' can't be converted to File object(s).
This will become a hard error in the future.
```

but I don't plan to work further on this branch.