### PR TITLE
eos-paygd: Add support for EOSPAYG_securitylevel

### DIFF
--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -8,6 +8,7 @@ eos_paygd_deps = [
   dependency('glib-2.0', version: '>= 2.44'),
   dependency('gobject-2.0', version: '>= 2.44'),
   dependency('libsystemd'),
+  dependency('efivar'),
   libgsystemservice_dep,
   libeos_payg_dep,
 ]

--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -41,9 +41,6 @@
 #define USR_LOCAL_SHARE_CONFIG_FILE_PATH PREFIX "/local/share/eos-payg/eos-payg.conf"
 #define USR_SHARE_CONFIG_FILE_PATH DATADIR "/eos-payg/eos-payg.conf"
 
-/* The GUID for the EOSPAYG_active EFI variable */
-#define EOSPAYG_ACTIVE_GUID EFI_GUID(0xd89c3871, 0xae0c, 0x4fc5, 0xa409, 0xdc, 0x71, 0x7a, 0xee, 0x61, 0xe7)
-
 static const GDBusErrorEntry epg_service_error_entries[] = {
   { EPG_SERVICE_ERROR_NO_PROVIDER, "com.endlessm.Payg1.Error.NoProvider" },
 };
@@ -303,7 +300,7 @@ epg_service_secure_init_sync (EpgService   *self,
   g_return_if_fail (EPG_IS_SERVICE (self));
 
   /* Read EFI variable(s) before the root pivot */
-  self->eospayg_active_efivar = (efi_get_variable_exists (EOSPAYG_ACTIVE_GUID, "EOSPAYG_active") == 0);
+  self->eospayg_active_efivar = (efi_get_variable_exists (EOSPAYG_GUID, "EOSPAYG_active") == 0);
 
   /* Look for enabled PAYG providers */
   loader = epg_provider_loader_new (NULL);

--- a/libeos-payg/service.h
+++ b/libeos-payg/service.h
@@ -25,6 +25,15 @@
 
 G_BEGIN_DECLS
 
+/* The security level is used to ensure that a system can't be "downgraded"
+ * to a version with a known security hole. Any time a release is made that
+ * fixes a security issue, this must be increased. It must never decrease.
+ */
+#define EPG_SECURITY_LEVEL 1
+
+/* The GUID for the EOSPAYG EFI variables */
+#define EOSPAYG_GUID EFI_GUID(0xd89c3871, 0xae0c, 0x4fc5, 0xa409, 0xdc, 0x71, 0x7a, 0xee, 0x61, 0xe7)
+
 /**
  * EpgServiceError:
  * @EPG_SERVICE_ERROR_NO_PROVIDER: No PAYG provider was found to be enabled,


### PR DESCRIPTION
Use an EFI variable to ensure we can't go back to an older
system with known PAYG bugs.

https://phabricator.endlessm.com/T27685