### PR TITLE
Add and use EpgProvider::unlocked signal

### DIFF
--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -186,6 +186,24 @@ epg_provider_default_init (EpgProviderInterface *iface)
   g_signal_new ("expired", G_TYPE_FROM_INTERFACE (iface),
                 G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL,
                 G_TYPE_NONE, 0);
+
+  /**
+   * EpgProvider::unlocked:
+   * @self: a #EpgProvider
+   *
+   * Emitted when the loan has been paid off completely and the computer should
+   * be unlocked for unrestricted use.
+   *
+   * #EpgProvider implementations need only emit this signal when the final
+   * unlocked code is entered, not when initialized on subsequent boots. This
+   * signal must be emitted before #EpgProvider:enabled is changed to %FALSE to
+   * ensure that the unlock is successful.
+   *
+   * Since: 0.2.3
+   */
+  g_signal_new ("unlocked", G_TYPE_FROM_INTERFACE (iface),
+                G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL,
+                G_TYPE_NONE, 0);
 }
 
 /**


### PR DESCRIPTION
Currently if one enters a final unlock code which pays off a computer's
loan, the EpgProvider object sets `enabled` to FALSE and sets the expiry
time far into the future, so that PAYG is no longer enforced. However,
since the EOSPAYG_active EFI variable is left set on Phase 4+ systems,
upon the next boot, eos-paygd will initiate a shutdown since it doesn't
expect state data to be in a "PAYG disabled" state while EOSPAYG_active
is set. Thus the user can't really use their paid off computer for more
than a few minutes at a time.

So this commit adds an `unlocked` signal to EpgProvider, which will be
emitted by the Angaza backend when the final unlock code has been
entered. The signal emission is caught by eos-paygd which deletes
EOSPAYG_active, so the computer will be free to use on the next boot
(and for the current boot as well).

An alternative implementation would be to use the existing callback
that's triggered whenever the `enabled` property changes, and do the
EOSPAYG_active deletion there. But that seems fragile to me, since a
provider is also considered disabled if it has not been provisioned
(e.g. the provider is for Paygee and the computer was provisioned for
Angaza) whereas a computer is only ever unlocked once. So, add a new
signal to match the expected semantics and make the code more
maintainable.

It doesn't make sense to implement this for EpgManager which is
deprecated, so there's also no way to test it in this repo. But we can
test it in the tests for the Angaza backend.

https://phabricator.endlessm.com/T28461