### PR TITLE
eos-payg: Add the account-id property

### DIFF
--- a/libeos-payg/errors.h
+++ b/libeos-payg/errors.h
@@ -32,6 +32,8 @@ G_BEGIN_DECLS
  * @EPG_MANAGER_ERROR_TOO_MANY_ATTEMPTS: Too many attempts to verify a code
  *    in recent history.
  * @EPG_MANAGER_ERROR_DISABLED: Pay as you go is disabled.
+ * @EPG_MANAGER_ERROR_DISPLAY_ACCOUNT_ID: The given code was valid, but instead of
+ *    adding time, tell the listener to show the account ID assigned to the machine.
  *
  * Errors which can be returned by #EpgManager.
  *
@@ -43,8 +45,9 @@ typedef enum
   EPG_MANAGER_ERROR_CODE_ALREADY_USED,
   EPG_MANAGER_ERROR_TOO_MANY_ATTEMPTS,
   EPG_MANAGER_ERROR_DISABLED,
+  EPG_MANAGER_ERROR_DISPLAY_ACCOUNT_ID,
 } EpgManagerError;
-#define EPG_MANAGER_N_ERRORS (EPG_MANAGER_ERROR_DISABLED + 1)
+#define EPG_MANAGER_N_ERRORS (EPG_MANAGER_ERROR_DISPLAY_ACCOUNT_ID + 1)
 
 GQuark epg_manager_error_quark (void);
 #define EPG_MANAGER_ERROR epg_manager_error_quark ()

--- a/libeos-payg/manager-interface.h
+++ b/libeos-payg/manager-interface.h
@@ -181,6 +181,15 @@ static const GDBusPropertyInfo manager_interface_code_format_suffix =
   NULL,  /* annotations */
 };
 
+static const GDBusPropertyInfo manager_interface_account_id =
+{
+  -1,  /* ref count */
+  (gchar *) "AccountID",
+  (gchar *) "s",
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
 static const GDBusPropertyInfo *manager_interface_properties[] =
 {
   &manager_interface_expiry_time,
@@ -189,6 +198,7 @@ static const GDBusPropertyInfo *manager_interface_properties[] =
   &manager_interface_code_format,
   &manager_interface_code_format_prefix,
   &manager_interface_code_format_suffix,
+  &manager_interface_account_id,
   NULL,
 };
 
@@ -208,6 +218,7 @@ static const gchar *manager_errors[] =
   "com.endlessm.Payg1.Error.CodeAlreadyUsed",
   "com.endlessm.Payg1.Error.TooManyAttempts",
   "com.endlessm.Payg1.Error.Disabled",
+  "com.endlessm.Payg1.Error.DisplayAccountID",
 };
 
 G_END_DECLS

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -129,7 +129,12 @@ static GVariant *epg_manager_service_manager_get_code_format_suffix (EpgManagerS
                                                                      const gchar           *interface_name,
                                                                      const gchar           *property_name,
                                                                      GDBusMethodInvocation *invocation);
-
+static GVariant *epg_manager_service_manager_get_account_id (EpgManagerService     *self,
+                                                             GDBusConnection       *connection,
+                                                             const gchar           *sender,
+                                                             const gchar           *interface_name,
+                                                             const gchar           *property_name,
+                                                             GDBusMethodInvocation *invocation);
 static void expired_cb (EpgProvider *provider,
                         gpointer     user_data);
 static void notify_cb  (GObject    *obj,
@@ -149,6 +154,8 @@ static const GDBusErrorEntry manager_error_map[] =
       "com.endlessm.Payg1.Error.TooManyAttempts" },
     { EPG_MANAGER_ERROR_DISABLED,
       "com.endlessm.Payg1.Error.Disabled" },
+    { EPG_MANAGER_ERROR_DISPLAY_ACCOUNT_ID,
+      "com.endlessm.Payg1.Error.DisplayAccountID" },
   };
 G_STATIC_ASSERT (G_N_ELEMENTS (manager_error_map) == EPG_MANAGER_N_ERRORS);
 G_STATIC_ASSERT (G_N_ELEMENTS (manager_error_map) == G_N_ELEMENTS (manager_errors));
@@ -663,6 +670,8 @@ manager_properties[] =
       epg_manager_service_manager_get_code_format_prefix, NULL  /* read-only */ },
     { "com.endlessm.Payg1", "CodeFormatSuffix", "code-format-suffix",
       epg_manager_service_manager_get_code_format_suffix, NULL  /* read-only */ },
+    { "com.endlessm.Payg1", "AccountID", "account-id",
+      epg_manager_service_manager_get_account_id, NULL  /* read-only */ },
   };
 
 G_STATIC_ASSERT (G_N_ELEMENTS (manager_properties) ==
@@ -958,6 +967,17 @@ epg_manager_service_manager_get_code_format_suffix (EpgManagerService     *self,
                                                     GDBusMethodInvocation *invocation)
 {
   return g_variant_new_string (epg_provider_get_code_format_suffix (self->provider));
+}
+
+static GVariant *
+epg_manager_service_manager_get_account_id (EpgManagerService     *self,
+                                            GDBusConnection       *connection,
+                                            const gchar           *sender,
+                                            const gchar           *interface_name,
+                                            const gchar           *property_name,
+                                            GDBusMethodInvocation *invocation)
+{
+  return g_variant_new_string (epg_provider_get_account_id (self->provider));
 }
 
 static void

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -431,17 +431,8 @@ epg_manager_set_property (GObject      *object,
     case PROP_EXPIRY_TIME:
     case PROP_RATE_LIMIT_END_TIME:
     case PROP_CODE_FORMAT:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_CODE_FORMAT_PREFIX:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_CODE_FORMAT_SUFFIX:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -37,6 +37,7 @@ static void epg_manager_provider_iface_init (gpointer g_iface,
 
 static void epg_manager_constructed  (GObject *object);
 static void epg_manager_dispose      (GObject *object);
+static void epg_manager_finalize     (GObject *object);
 
 static void epg_manager_get_property (GObject      *object,
                                       guint         property_id,
@@ -93,6 +94,7 @@ static guint64     epg_manager_get_expiry_time     (EpgProvider *provider);
 static gboolean    epg_manager_get_enabled         (EpgProvider *provider);
 static guint64     epg_manager_get_rate_limit_end_time (EpgProvider *provider);
 static EpgClock *  epg_manager_get_clock (EpgProvider *provider);
+static const gchar * epg_manager_get_account_id (EpgProvider *provider);
 
 /* Struct for storing the values in a used-codes file. The alignment and
  * size of this struct are file format ABI, and must be kept the same. */
@@ -146,6 +148,7 @@ struct _EpgManager
   GFile *key_file;  /* (owned) */
   GBytes *key_bytes;  /* (owned) */
   EpgClock *clock; /* (owned) */
+  const gchar *account_id; /* (owned) */
 
   GFile *state_directory;  /* (owned) */
 
@@ -186,6 +189,7 @@ typedef enum
   PROP_CODE_FORMAT_PREFIX,
   PROP_CODE_FORMAT_SUFFIX,
   PROP_CLOCK,
+  PROP_ACCOUNT_ID,
 } EpgManagerProperty;
 
 G_DEFINE_TYPE_WITH_CODE (EpgManager, epg_manager, G_TYPE_OBJECT,
@@ -203,6 +207,7 @@ epg_manager_class_init (EpgManagerClass *klass)
 
   object_class->constructed = epg_manager_constructed;
   object_class->dispose = epg_manager_dispose;
+  object_class->finalize = epg_manager_finalize;
   object_class->get_property = epg_manager_get_property;
   object_class->set_property = epg_manager_set_property;
 
@@ -213,6 +218,7 @@ epg_manager_class_init (EpgManagerClass *klass)
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
+  g_object_class_override_property (object_class, PROP_ACCOUNT_ID, "account-id");
 
   /**
    * EpgManager:key-file:
@@ -280,6 +286,7 @@ epg_manager_provider_iface_init (gpointer g_iface,
   iface->get_enabled = epg_manager_get_enabled;
   iface->get_rate_limit_end_time = epg_manager_get_rate_limit_end_time;
   iface->get_clock = epg_manager_get_clock;
+  iface->get_account_id = epg_manager_get_account_id;
 
   iface->code_format = "^[0-9]{8}$";
   iface->code_format_prefix = "";
@@ -326,6 +333,8 @@ epg_manager_constructed (GObject *object)
 
   if (self->clock == NULL)
     self->clock = EPG_CLOCK (epg_real_clock_new ());
+
+  self->account_id = g_strdup ("");
 }
 
 static void
@@ -350,6 +359,17 @@ epg_manager_dispose (GObject *object)
 
   /* Chain up to the parent class */
   G_OBJECT_CLASS (epg_manager_parent_class)->dispose (object);
+}
+
+static void
+epg_manager_finalize (GObject *object)
+{
+  EpgManager *self = EPG_MANAGER (object);
+
+  g_free ((gchar *) self->account_id);
+
+  /* Chain up to the parent class */
+  G_OBJECT_CLASS (epg_manager_parent_class)->finalize (object);
 }
 
 static void
@@ -390,6 +410,9 @@ epg_manager_get_property (GObject    *object,
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
+    case PROP_ACCOUNT_ID:
+      g_value_set_static_string (value, epg_provider_get_account_id (provider));
+      break;
     default:
       g_assert_not_reached ();
     }
@@ -416,6 +439,10 @@ epg_manager_set_property (GObject      *object,
       g_assert_not_reached ();
       break;
     case PROP_CODE_FORMAT_SUFFIX:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();
       break;
@@ -1712,4 +1739,14 @@ epg_manager_get_clock (EpgProvider *provider)
   g_return_val_if_fail (EPG_IS_MANAGER (self), NULL);
 
   return self->clock;
+}
+
+static const gchar *
+epg_manager_get_account_id (EpgProvider *provider)
+{
+  EpgManager *self = EPG_MANAGER (provider);
+
+  g_return_val_if_fail (EPG_IS_MANAGER (self), NULL);
+
+  return self->account_id;
 }

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -169,6 +169,22 @@ epg_provider_default_init (EpgProviderInterface *iface)
   g_object_interface_install_property (iface, pspec);
 
   /**
+   * EpgProvider:account-id:
+   *
+   * A gchar representing the user's account id.
+   *
+   * This property is constant once the provider is initialized.
+   *
+   * Since: 0.2.3
+   */
+  pspec =
+      g_param_spec_string ("account-id", "AccountID",
+                           "The user's account number ",
+                           "",
+                           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+  g_object_interface_install_property (iface, pspec);
+
+  /**
    * EpgProvider::expired:
    * @self: a #EpgProvider
    *
@@ -224,6 +240,10 @@ epg_provider_default_init (EpgProviderInterface *iface)
  * a given time period, %EPG_MANAGER_ERROR_TOO_MANY_ATTEMPTS will be returned
  * until that period expires. The rate limiting history is reset on a successful
  * verification of a code. 
+ *
+ * Also, %EPG_MANAGER_ERROR_DISPLAY_ACCOUNT_ID can be returned in the event the user
+ * inserts a code to show the account identifier for the machine, and this should
+ * be handled by the provider. 
  *
  * @time_added is signed because some implementations can reduce the available credit
  * when you add a new code.
@@ -505,4 +525,23 @@ epg_provider_get_clock (EpgProvider *self)
   g_assert (iface->get_clock != NULL);
 
   return iface->get_clock (self);
+}
+
+/**
+ * epg_provider_get_account_id:
+ * @self: a #EpgProvider
+ *
+ * Get the value of #EpgProvider:account-id
+ *
+ * Returns: An account id refering to the user's account number
+ * Since: 0.2.3
+ */
+const gchar *
+epg_provider_get_account_id (EpgProvider *self)
+{
+  g_return_val_if_fail (EPG_IS_PROVIDER (self), NULL);
+
+  EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
+
+  return iface->get_account_id (self);
 }

--- a/libeos-payg/provider.h
+++ b/libeos-payg/provider.h
@@ -56,6 +56,7 @@ struct _EpgProviderInterface
   gboolean        (*get_enabled)             (EpgProvider *self);
   guint64         (*get_rate_limit_end_time) (EpgProvider *self);
   EpgClock       *(*get_clock)               (EpgProvider *self);
+  const gchar    *(*get_account_id)          (EpgProvider *self);
 
   const gchar *     code_format;
   const gchar *     code_format_prefix;
@@ -87,5 +88,6 @@ const gchar *   epg_provider_get_code_format         (EpgProvider *self);
 const gchar *   epg_provider_get_code_format_prefix  (EpgProvider *self);
 const gchar *   epg_provider_get_code_format_suffix  (EpgProvider *self);
 EpgClock *      epg_provider_get_clock               (EpgProvider *self);
+const gchar *   epg_provider_get_account_id          (EpgProvider *self);
 
 G_END_DECLS

--- a/libeos-payg/tests/manager.c
+++ b/libeos-payg/tests/manager.c
@@ -372,6 +372,21 @@ write_valid_clock_time_file (Fixture *fixture)
   g_assert_true (ret);
 }
 
+/* test_account_id:
+ *
+ * Tests that the :account_id is properly returned.
+ */
+static void
+test_manager_account_id (Fixture *fixture,
+                         gconstpointer data)
+{
+  manager_new (fixture);
+
+  const gchar *account_id = epg_provider_get_account_id (fixture->provider);
+
+  g_assert_cmpstr (account_id, ==, "");
+}
+
 /* test_manager_load_error_malformed:
  * @data: offset within Fixture of the path to a state file, which will be
  * initialized to an invalid value
@@ -876,6 +891,7 @@ main (int    argc,
   T ("/manager/add-infinite", test_manager_add_infinite_code, NULL);
   T ("/manager/get-code-format-prefix", test_manager_code_format_prefix, NULL);
   T ("/manager/get-code-format-suffix", test_manager_code_format_suffix, NULL);
+  T ("/manager/get-account-id", test_manager_account_id, NULL);
   T ("/manager/error/malformed", test_manager_error_malformed, NULL);
   T ("/manager/error/reused", test_manager_error_reused, NULL);
   T ("/manager/error/rate-limit", test_manager_error_rate_limit, NULL);

--- a/libeos-payg/tests/plugins/test-provider.c
+++ b/libeos-payg/tests/plugins/test-provider.c
@@ -200,17 +200,8 @@ epg_test_provider_set_property (GObject      *object,
     case PROP_EXPIRY_TIME:
     case PROP_RATE_LIMIT_END_TIME:
     case PROP_CODE_FORMAT:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_CODE_FORMAT_PREFIX:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_CODE_FORMAT_SUFFIX:
-      /* Read only. */
-      g_assert_not_reached ();
-      break;
     case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();

--- a/libeos-payg/tests/plugins/test-provider.c
+++ b/libeos-payg/tests/plugins/test-provider.c
@@ -63,11 +63,13 @@ static guint64     epg_test_provider_get_expiry_time     (EpgProvider *provider)
 static gboolean    epg_test_provider_get_enabled         (EpgProvider *provider);
 static guint64     epg_test_provider_get_rate_limit_end_time (EpgProvider *provider);
 static EpgClock *  epg_test_provider_get_clock (EpgProvider *provider);
+static const gchar *  epg_test_provider_get_account_id (EpgProvider *provider);
 
 typedef struct
 {
   gboolean enabled;
   EpgClock *clock; /* (owned) */
+  const gchar *account_id; /* (owned) */
 } EpgTestProviderPrivate;
 
 typedef enum
@@ -79,6 +81,7 @@ typedef enum
   PROP_CODE_FORMAT_PREFIX,
   PROP_CODE_FORMAT_SUFFIX,
   PROP_CLOCK,
+  PROP_ACCOUNT_ID,
 } EpgTestProviderProperty;
 
 G_DEFINE_TYPE_WITH_CODE (EpgTestProvider, epg_test_provider, G_TYPE_OBJECT,
@@ -105,6 +108,7 @@ epg_test_provider_class_init (EpgTestProviderClass *klass)
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
+  g_object_class_override_property (object_class, PROP_ACCOUNT_ID, "account-id");
 }
 
 static void
@@ -131,6 +135,7 @@ epg_test_provider_provider_iface_init (gpointer g_iface,
   iface->get_enabled = epg_test_provider_get_enabled;
   iface->get_rate_limit_end_time = epg_test_provider_get_rate_limit_end_time;
   iface->get_clock = epg_test_provider_get_clock;
+  iface->get_account_id = epg_test_provider_get_account_id;
   iface->code_format = "";
   iface->code_format_prefix = "";
   iface->code_format_suffix = "";
@@ -173,6 +178,9 @@ epg_test_provider_get_property (GObject    *object,
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
+    case PROP_ACCOUNT_ID:
+      g_value_set_static_string (value, epg_provider_get_account_id (provider));
+      break;
     default:
       g_assert_not_reached ();
     }
@@ -200,6 +208,10 @@ epg_test_provider_set_property (GObject      *object,
       g_assert_not_reached ();
       break;
     case PROP_CODE_FORMAT_SUFFIX:
+      /* Read only. */
+      g_assert_not_reached ();
+      break;
+    case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();
       break;
@@ -361,4 +373,16 @@ epg_test_provider_get_clock (EpgProvider *provider)
   EpgTestProviderPrivate *priv = epg_test_provider_get_instance_private (self);
 
   return priv->clock;
+}
+
+static const gchar *
+epg_test_provider_get_account_id (EpgProvider *provider)
+{
+  EpgTestProvider *self = EPG_TEST_PROVIDER (provider);
+
+  g_return_val_if_fail (EPG_IS_TEST_PROVIDER (self), NULL);
+
+  EpgTestProviderPrivate *priv = epg_test_provider_get_instance_private (self);
+
+  return priv->account_id;
 }


### PR DESCRIPTION
Add an account-id property to be shown on the user's unlock
screen every time he adds a Pay-As-You-Go credit. As of now, we
don't assign a proper code to the user, so this is mostly a
foundation for the eos-payg-nonfree module.

https://phabricator.endlessm.com/T28491