### PR TITLE
Add util function for checking if this is a legacy or modern PAYG system

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -238,7 +238,6 @@ main (int   argc,
   g_autoptr(GFile) state_dir = NULL;
   int ret, sd_notify_ret, system_ret;
   int lsm_fd;
-  gboolean backward_compat_mode = FALSE;
   guint timeout_id = 0, watchdog_id = 0;
   const gchar *sd_socket_env = NULL;
   g_autofree char *sd_socket_dir = NULL;
@@ -318,7 +317,7 @@ main (int   argc,
        * unsupported on those grub systems, like state data encryption.
        * https://phabricator.endlessm.com/T27524 */
       g_debug ("eos-paygd running from root filesystem, entering backward compat mode");
-      backward_compat_mode = TRUE;
+      payg_internal_set_legacy_mode();
     }
 
   /* Allow writes to /dev/mmcblk?boot0. This requires writing to a special file
@@ -334,7 +333,7 @@ main (int   argc,
 
   g_debug ("epg_service_secure_init_sync() completed");
 
-  if (!backward_compat_mode)
+  if (!payg_get_legacy_mode ())
     {
       if (enforcing_mode && payg_should_use_watchdog ())
         {

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -28,6 +28,8 @@
 
 #define EFI_GLOBAL_VARIABLE_GUID EFI_GUID(0x8be4df61, 0x93ca, 0x11d2, 0xaa0d, 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c)
 
+static gboolean payg_legacy_mode = FALSE;
+
 /* Force a poweroff in situations where we are not able to enforce PAYG. This
  * is intended to be used as a GSourceFunc, e.g. with g_timeout_add_seconds()
  */
@@ -262,4 +264,28 @@ payg_should_check_securitylevel (void)
     return FALSE;
 
   return TRUE;
+}
+
+/**
+ * payg_get_legacy_mode:
+ *
+ * If eospaygd is running in Phase 2 mode, returns %TRUE, otherwise returns
+ * %FALSE
+ */
+gboolean payg_get_legacy_mode (void)
+{
+  return payg_legacy_mode;
+}
+
+/**
+ * payg_internal_set_legacy_mode:
+ *
+ * To be called by eospaygd to initialize the value returned by
+ * payg_get_legacy_mode. Should be called once, only on Phase 2
+ * systems (where eos-paygd is run from the primary filesystem
+ * not the initramfs).
+ */
+void payg_internal_set_legacy_mode (void)
+{
+  payg_legacy_mode = TRUE;
 }

--- a/libeos-payg/util.h
+++ b/libeos-payg/util.h
@@ -33,5 +33,7 @@ gboolean payg_get_eospayg_active_set (void);
 gboolean payg_should_use_watchdog (void);
 gboolean payg_should_use_lsm (void);
 gboolean payg_should_check_securitylevel (void);
+gboolean payg_get_legacy_mode (void);
+void payg_internal_set_legacy_mode (void);
 
 G_END_DECLS


### PR DESCRIPTION
We need a way for plugins to check if they should use modern or legacy
code paths. This will allow us to, for example, disable datastore
encryption on phase 2 deployments.

https://phabricator.endlessm.com/T27052