### PR TITLE
debian/control: Add gtk-doc-tools dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  python3-dbusmock,
  dracut,
  libefivar-dev,
+ gtk-doc-tools,
 
 Package: eos-paygd
 Section: misc


### PR DESCRIPTION
This is needed for building libgsystemservice. We may also want to use
it in the future to compile the gtk-doc comments we have in the source
into HTML.

https://phabricator.endlessm.com/T29330