### PR TITLE
eos-paygd: Add RTC updating

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -308,6 +308,13 @@ main (int   argc,
           g_warning ("Security level regressed, forced shutdown will occur in 20 minutes.");
           g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
         }
+
+      /* Setup RTC updater before the root pivot */
+      if (enforcing_mode && !payg_hwclock_init ())
+        {
+          g_warning ("RTC failure, forced shutdown will occur in 20 minutes.");
+          g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
+        }
     }
   else
     {

--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -1,0 +1,151 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2020 Endless OS Foundation LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms of the
+ * GNU Lesser General Public License Version 2.1 or later (the "LGPL"), in
+ * which case the provisions of the LGPL are applicable instead of those above.
+ * If you wish to allow use of your version of this file only under the terms
+ * of the LGPL, and not to allow others to use your version of this file under
+ * the terms of the MPL, indicate your decision by deleting the provisions
+ * above and replace them with the notice and other provisions required by the
+ * LGPL. If you do not delete the provisions above, a recipient may use your
+ * version of this file under the terms of either the MPL or the LGPL.
+ */
+
+#include <util.h>
+#include <linux/rtc.h>
+#include <sys/time.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+static int rtc_fd = -1;
+static gboolean queued = FALSE;
+static gboolean warned = FALSE;
+
+/* Sets the hardware clock to the system clock time - this
+ * assumes the hardware clock is in local time and not UTC,
+ * which is the default on a fresh endless install.
+ */
+static gboolean
+payg_hwclock_update (gpointer unused)
+{
+  int err;
+  time_t time_sec;
+  struct tm local_time;
+
+  /* We make a trivial effort to prevent doing a stack of
+   * time updates on the same main loop iteration, but
+   * we don't try very hard because it doesn't matter
+   * too much.
+   */
+  queued = FALSE;
+
+  time (&time_sec);
+  localtime_r (&time_sec, &local_time);
+
+  /* The RTC docs indicate the third param should be
+   * struct rtc_time, however hwclock-rtc.c in util-linux
+   * uses a struct tm. This works because the structs
+   * are identical.
+   */
+  err = ioctl (rtc_fd, RTC_SET_TIME, &local_time);
+  if (err != 0 && !warned)
+    {
+      warned = TRUE;
+      g_warning ("Failed to update hardware clock");
+    }
+  return FALSE;
+}
+
+/**
+ * payg_hwclock_queue_update:
+ *
+ * Schedule the system clock to be written to the hardware
+ * clock on the next main loop iteration.
+ */
+void
+payg_hwclock_queue_update (void)
+{
+  /* If we failed to init the clock, we're still running for
+   * 20 minutes until forced shutdown - so we must check for
+   * fd validity, but we don't need to log anything else.
+   */
+  if (rtc_fd == -1)
+    return;
+
+  if (!queued)
+    {
+      queued = TRUE;
+      g_idle_add (payg_hwclock_update, NULL);
+    }
+}
+
+static gboolean
+source_hwclock_update (gpointer unused)
+{
+  payg_hwclock_queue_update ();
+  return TRUE;
+}
+
+/* payg_hwclock_init:
+ *
+ * Initialize hardware clock subsystem.
+ * This must be called before the root pivot.
+ *
+ * Returns: %TRUE on success, %FAIL otherwise
+ */
+gboolean
+payg_hwclock_init (void)
+{
+  time_t sys_time, rtc_time;
+  struct tm rtc_tm;
+  int err;
+
+  rtc_fd = open ("/dev/rtc", O_RDWR);
+  if (rtc_fd == -1)
+    {
+      g_warning ("Failed to open RTC device");
+      return FALSE;
+    }
+
+  /* If the system time and RTC time aren't roughly similar
+   * then systemd has bumped the time to be newer than its
+   * NEWS file was at build time.
+   *
+   * This almost certainly means the RTC is broken or has
+   * been reset by battery removal, so fail out.
+   */
+  err = ioctl (rtc_fd, RTC_RD_TIME, &rtc_tm);
+  if (err != 0)
+    {
+      g_warning ("Failed to read RTC");
+      return FALSE;
+    }
+  rtc_time = mktime (&rtc_tm);
+  time (&sys_time);
+  /* Knock off a few binary digits to be safe, this will
+   * drop a few days of precision. If the clock was reset
+   * by battery removal, it will shift years.
+   */
+  rtc_time >>= 19;
+  sys_time >>= 19;
+  if (rtc_time < sys_time)
+    {
+      g_warning ("RTC out of sync with system clock at boot");
+      return FALSE;
+    }
+
+  /* Set up a timer to update the hwclock every 659 seconds,
+   * just like ntp would on a normal system.
+   */
+  g_timeout_add_seconds (659, source_hwclock_update, NULL);
+
+  return TRUE;
+}

--- a/libeos-payg/meson.build
+++ b/libeos-payg/meson.build
@@ -4,6 +4,7 @@ libeos_payg_sources = [
   'clock.c',
   'errors.c',
   'fake-clock.c',
+  'hwclock.c',
   'manager.c',
   'manager-service.c',
   'multi-task.c',

--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -247,6 +247,8 @@ clock_jump_cb (gpointer user_data)
   self->clock_realtime_secs_v0 = clock_realtime_secs_v1;
   self->clock_boottime_secs_v0 = clock_boottime_secs_v1;
 
+  payg_hwclock_queue_update ();
+
   return G_SOURCE_CONTINUE;
 }
 

--- a/libeos-payg/service.h
+++ b/libeos-payg/service.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
  * to a version with a known security hole. Any time a release is made that
  * fixes a security issue, this must be increased. It must never decrease.
  */
-#define EPG_SECURITY_LEVEL 1
+#define EPG_SECURITY_LEVEL 2
 
 /**
  * EpgServiceError:

--- a/libeos-payg/util.h
+++ b/libeos-payg/util.h
@@ -35,5 +35,7 @@ gboolean payg_should_use_lsm (void);
 gboolean payg_should_check_securitylevel (void);
 gboolean payg_get_legacy_mode (void);
 void payg_internal_set_legacy_mode (void);
+void payg_hwclock_queue_update (void);
+gboolean payg_hwclock_init (void);
 
 G_END_DECLS


### PR DESCRIPTION
In certain circumstances the RTC and the system clock can be out of sync
with eachother. This causes problems for accurate time keeping over a
reboot.

Make eos-paygd keep the two in sync.

https://phabricator.endlessm.com/T30571