### PR TITLE
efi: Add a function to check for SecureBootOption

### DIFF
--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -18,6 +18,8 @@
 #define EOSPAYG_GUID         "d89c3871-ae0c-4fc5-a409-dc717aee61e7"
 #define GLOBAL_VARIABLE_GUID "8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
+/* Can't figure out who owns this GUID. ECS and Lenovo have both used it */
+#define SBO_VARIABLE_GUID    "955b9041-133a-4bcf-90d1-97e1693c0e30"
 #define NVM_PREFIX           "EOSPAYG_"
 
 /* Totally bogus low performance mock storage for dry runs.
@@ -472,6 +474,36 @@ eospayg_efi_secureboot_active (void)
     return FALSE;
 
   return !!content[0];
+}
+
+/* eospayg_efi_securebootoption_disabled
+ *
+ * Check if the SecureBootOption EFI variable exists and
+ * is disabled.
+ *
+ * The oddly inverted logic is due to the fact that most
+ * systems don't have this variable at all - if it doesn't
+ * exist, we can infer nothing about the state of Secure Boot,
+ * if it does it tells us if Secure Boot is on or off.
+ *
+ * Thus, on and not existing should likely be treated in the
+ * same way by a caller, but existing and off is a red flag
+ * for PAYG enforcement.
+ *
+ * Returns: %TRUE if the variable exists and is disabled, %FLASE otherwise
+ */
+gboolean
+eospayg_efi_securebootoption_disabled (void)
+{
+  g_autofree char *tname = full_efi_name (SBO_VARIABLE_GUID, "SecureBootOption");
+  g_autofree unsigned char *content = NULL;
+  int size;
+
+  content = efivarfs_read (tname, &size);
+  if (!content || size != 1)
+    return FALSE;
+
+  return !content[0];
 }
 
 /* eospayg_efi_var_read:

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -20,6 +20,7 @@ gboolean eospayg_efi_var_delete (const char *name);
 gboolean eospayg_efi_var_delete_fullname (const char *name);
 gboolean eospayg_efi_var_exists (const char *name);
 gboolean eospayg_efi_secureboot_active (void);
+gboolean eospayg_efi_securebootoption_disabled (void);
 gboolean eospayg_efi_var_supported (void);
 void eospayg_efi_list_rewind (void);
 const char *eospayg_efi_list_next (void);


### PR DESCRIPTION
This variable is non-standard and weird, but in the cases it
exists it might be useful to query.

https://phabricator.endlessm.com/T31337