### PR TITLE
eos-paygd: Stop using deprecated Killmode for legacy eos-paygd

### DIFF
--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -13,9 +13,6 @@ NotifyAccess=main
 # We must be root to avoid systemd's post-root-pivot killing spree
 # and to make the eMMC boot partition writable
 User=root
-# Set KillMode and SendSIGKILL such that we're not stopped along with the associated target
-KillMode=none
-SendSIGKILL=no
 
 # Sandboxing
 # We might need access to /dev/mmcblkxboot0

--- a/eos-paygd/eos-paygd.service.in
+++ b/eos-paygd/eos-paygd.service.in
@@ -10,8 +10,7 @@ ExecStart=@libexecdir@/eos-paygd1
 Type=dbus
 BusName=com.endlessm.Payg1
 NotifyAccess=main
-# We must be root to avoid systemd's post-root-pivot killing spree
-# and to make the eMMC boot partition writable
+# We must be root to make the eMMC boot partition writable
 User=root
 
 # Sandboxing


### PR DESCRIPTION
Killmode=None is deprecated, and will eventually stop working. Also, its
use is only currently important for eos-paygd when run from the initramfs,
so we can simply drop it from the legacy service (that launches it from
the rootfs)

https://phabricator.endlessm.com/T31590