### PR TITLE
eos-paygd: Stop using deprecated KillMode=None

### DIFF
--- a/eos-paygd/eos-paygd-2.service.in
+++ b/eos-paygd/eos-paygd-2.service.in
@@ -23,6 +23,10 @@ FailureAction=poweroff
 After=initrd-root-fs.target
 Before=initrd-parse-etc.service
 Conflicts=shutdown.target
+# We need IgnoreOnIsolate to prevent systemd from trying to shut us down during
+# the root pivot. This is independent of the tricks in the daemon itself to avoid
+# the pivot killing spree.
+IgnoreOnIsolate=true
 
 [Service]
 ExecStart=@libexecdir@/eos-paygd1
@@ -32,9 +36,6 @@ NotifyAccess=main
 # We must be root to avoid systemd's post-root-pivot killing spree
 # and to make the eMMC boot partition writable
 User=root
-# Set KillMode and SendSIGKILL such that we're not stopped along with the associated target
-KillMode=none
-SendSIGKILL=no
 
 # Sandboxing
 # We need access to /dev/watchdog and /dev/mmcblkxboot0 at least


### PR DESCRIPTION
We use KillMode=None so systemd doesn't try to kill our process, but this
has been deprecated because it prevents systemd from trying to kill
processes.

Instead, we switch to IgnoreOnIsolate=true, which tells systemd not to
(try to) shut down the process when performing isolation, such as at
root pivot and shutdown.

We already renamed out process to avoid the systemd root-pivot killing
spree, however that alone doesn't prevent systemd from trying to manage
service life-cycle.

Our process remains unkillable, and systemd will shut the computer down
immediately if a user tries to stop the service.

https://phabricator.endlessm.com/T31590