### PR TITLE
readme: Make a note regarding shutdown during nv write

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ running from a payg image, and (2) when run from the primary root filesystem,
 it does not use the advanced security features and assumes it's running on a
 Phase 2 PAYG system or a non-PAYG system.
 
+When running from the initramfs, eos-paygd is unkillable. systemd will leave
+it running during the root pivot and shutdown. The reason this is safe, and
+that a system shutdown while it's writing to non-volatile storage isn't
+considered a risk is that all the non-volatile storage backends in use are
+robust against a shutdown during write. This is done either through the
+ability to rollback an interrupted write, or writes that are fully atomic.
+
+Since it would be very difficult to enter a timecode at the same time as
+a system shutdown (because the UI would not be accessible during shutdown),
+the most likely interrupted operation would be time expiry. On the following
+boot the time would still be past expiration time, and the system would lock
+again.
+
 Dependencies
 ============
 


### PR DESCRIPTION
We've recently discussed the possibility of system shutdown interrupting
a write to non volatile storage. The conclusion is that eos-paygd is
safe against these interruptions, so we don't have to deal with
shutting the daemon down cleanly and all that entails.

However, the reason it's safe is because all currently in use nv storage
backends can handle interrupted writes safely (this does not include the
file backend, which is not used in the real world).

Make a note of this in the README so future developers realize both that
shutdown is safe, and that atomicity is a critical design criteria for
the storage backends to maintain this safety.

https://phabricator.endlessm.com/T27718