### PR TITLE
hwclock: Print the for failing to opening the RTC

### DIFF
--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <errno.h>
 
 static int rtc_fd = -1;
 static gboolean queued = FALSE;
@@ -111,7 +112,7 @@ payg_hwclock_init (void)
   rtc_fd = open ("/dev/rtc", O_RDWR);
   if (rtc_fd == -1)
     {
-      g_warning ("Failed to open RTC device");
+      g_warning ("Failed to open RTC device: %s", g_strerror (errno));
       return FALSE;
     }
 


### PR DESCRIPTION
This will aid in diagnosing when the RTC hardware is busted the daemon
enforces the PAYG lock and forces a shutdown. We have seen this failing
on some ECS EF20EA machines in the field, but without having access to
the machines we can't determine why it fails. We suspect a hardware
failure, but having the actual error printed on the logs will be help.

https://phabricator.endlessm.com/T32703