### PR TITLE
hwclock: Keep the RTC in UTC

### DIFF
--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -30,9 +30,9 @@ static int rtc_fd = -1;
 static gboolean queued = FALSE;
 static gboolean warned = FALSE;
 
-/* Sets the hardware clock to the system clock time - this
- * assumes the hardware clock is in local time and not UTC,
- * which is the default on a fresh endless install.
+/* Sets the hardware clock to the system clock time
+ * Note: this assumes the hardware clock is in UTC, which
+ * should always be the case for standalone EOS systems.
  */
 static gboolean
 payg_hwclock_update (gpointer unused)
@@ -49,7 +49,7 @@ payg_hwclock_update (gpointer unused)
   queued = FALSE;
 
   time (&now_sec);
-  localtime_r (&now_sec, &now_tm);
+  gmtime_r (&now_sec, &now_tm);
 
   /* The RTC docs indicate the third param should be
    * struct rtc_time, however hwclock-rtc.c in util-linux
@@ -131,7 +131,7 @@ payg_hwclock_init (void)
       g_warning ("Failed to read RTC: %s", g_strerror (errno));
       return FALSE;
     }
-  rtc_secs = mktime (&rtc_tm);
+  rtc_secs = timegm (&rtc_tm);
   time (&sys_secs);
   g_debug ("RTC time:        %s", asctime (&rtc_tm));
   g_debug ("system UTC time: %s", asctime (gmtime (&sys_secs)));

--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -38,8 +38,8 @@ static gboolean
 payg_hwclock_update (gpointer unused)
 {
   int err;
-  time_t time_sec;
-  struct tm local_time;
+  time_t now_sec;
+  struct tm now_tm;
 
   /* We make a trivial effort to prevent doing a stack of
    * time updates on the same main loop iteration, but
@@ -48,15 +48,15 @@ payg_hwclock_update (gpointer unused)
    */
   queued = FALSE;
 
-  time (&time_sec);
-  localtime_r (&time_sec, &local_time);
+  time (&now_sec);
+  localtime_r (&now_sec, &now_tm);
 
   /* The RTC docs indicate the third param should be
    * struct rtc_time, however hwclock-rtc.c in util-linux
    * uses a struct tm. This works because the structs
    * are identical.
    */
-  err = ioctl (rtc_fd, RTC_SET_TIME, &local_time);
+  err = ioctl (rtc_fd, RTC_SET_TIME, &now_tm);
   if (err != 0 && !warned)
     {
       warned = TRUE;

--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -105,7 +105,7 @@ source_hwclock_update (gpointer unused)
 gboolean
 payg_hwclock_init (void)
 {
-  time_t sys_time, rtc_time;
+  time_t sys_secs, rtc_secs;
   struct tm rtc_tm;
   int err;
 
@@ -129,15 +129,15 @@ payg_hwclock_init (void)
       g_warning ("Failed to read RTC: %s", g_strerror (errno));
       return FALSE;
     }
-  rtc_time = mktime (&rtc_tm);
-  time (&sys_time);
+  rtc_secs = mktime (&rtc_tm);
+  time (&sys_secs);
   /* Knock off a few binary digits to be safe, this will
    * drop a few days of precision. If the clock was reset
    * by battery removal, it will shift years.
    */
-  rtc_time >>= 19;
-  sys_time >>= 19;
-  if (rtc_time < sys_time)
+  rtc_secs >>= 19;
+  sys_secs >>= 19;
+  if (rtc_secs < sys_secs)
     {
       g_warning ("RTC out of sync with system clock at boot");
       return FALSE;

--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -62,6 +62,8 @@ payg_hwclock_update (gpointer unused)
       warned = TRUE;
       g_warning ("Failed to update hardware clock: %s", g_strerror (errno));
     }
+  else
+      g_debug ("Updated RTC time to %s", asctime (&now_tm));
   return FALSE;
 }
 
@@ -131,6 +133,10 @@ payg_hwclock_init (void)
     }
   rtc_secs = mktime (&rtc_tm);
   time (&sys_secs);
+  g_debug ("RTC time:        %s", asctime (&rtc_tm));
+  g_debug ("system UTC time: %s", asctime (gmtime (&sys_secs)));
+  g_debug ("RTC secs:        %ld\n", rtc_secs);
+  g_debug ("system UTC secs: %ld\n", sys_secs);
   /* Knock off a few binary digits to be safe, this will
    * drop a few days of precision. If the clock was reset
    * by battery removal, it will shift years.

--- a/libeos-payg/hwclock.c
+++ b/libeos-payg/hwclock.c
@@ -60,7 +60,7 @@ payg_hwclock_update (gpointer unused)
   if (err != 0 && !warned)
     {
       warned = TRUE;
-      g_warning ("Failed to update hardware clock");
+      g_warning ("Failed to update hardware clock: %s", g_strerror (errno));
     }
   return FALSE;
 }
@@ -126,7 +126,7 @@ payg_hwclock_init (void)
   err = ioctl (rtc_fd, RTC_RD_TIME, &rtc_tm);
   if (err != 0)
     {
-      g_warning ("Failed to read RTC");
+      g_warning ("Failed to read RTC: %s", g_strerror (errno));
       return FALSE;
     }
   rtc_time = mktime (&rtc_tm);


### PR DESCRIPTION
Since when payg is enforced we disable the kernel SYSTOHC functionality
and prevent any other userspace process from accessing the RTC,
eos-paygd effectively becomes responsive for keeping the RTC up-to-date.

This code previously assumed the RTC was configured to use the local
time, which is not actually the case -- the RTC will always use UTC on
standalone Endless OS installations.

This commit changes eos-paygd behavior to always store the UTC time in
the RTC, and treat values read from the RTC as UTC time.

https://phabricator.endlessm.com/T32733