### PR TITLE
paygd: Request a poweroff on SIGTERM / SIGINT

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -531,9 +531,8 @@ main (int   argc,
         }
       else if (g_error_matches (error, GSS_SERVICE_ERROR, GSS_SERVICE_ERROR_SIGNALLED))
         {
-          g_warning ("EpgService exited with GSS_SERVICE_ERROR_SIGNALLED");
-          raise (gss_service_get_exit_signal (GSS_SERVICE (service)));
-          ret = FATAL_SIGNAL_EXIT_CODE; /* should not be reached, just in case the signal is caught */
+          /* The service received SIGTERM or SIGINT */
+          ret = FATAL_SIGNAL_EXIT_CODE;
         }
       else
         {

--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -281,7 +281,7 @@ main (int   argc,
           g_warning ("Unable to access EFI variables, shutting down in %d minutes",
                      TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
           g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
-                                 payg_sync_and_poweroff, NULL);
+                                 payg_system_poweroff, NULL);
         }
 
       payg_set_debug_env_vars ();
@@ -318,7 +318,7 @@ main (int   argc,
           g_warning ("Security level regressed, shutting down in %d minutes",
                      TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
           g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
-                                 payg_sync_and_poweroff, NULL);
+                                 payg_system_poweroff, NULL);
         }
 
       /* Setup RTC updater before the root pivot */
@@ -327,7 +327,7 @@ main (int   argc,
           g_warning ("RTC failure, shutting down in %d minutes",
                      TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
           g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
-                                 payg_sync_and_poweroff, NULL);
+                                 payg_system_poweroff, NULL);
         }
     }
   else
@@ -455,7 +455,7 @@ main (int   argc,
        * flatpaks occur during a reboot. */
       g_debug ("Attempting to connect to D-Bus daemon");
       timeout_id = g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
-                                          payg_sync_and_poweroff, NULL);
+                                          payg_system_poweroff, NULL);
       while (TRUE)
         {
           g_autoptr(GDBusConnection) bus_connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
@@ -466,7 +466,7 @@ main (int   argc,
 
               /* Keep pinging the watchdog if we have it, but don't block in
                * case we don't have it. We also need to iterate the main
-               * context for payg_sync_and_poweroff() to have a chance to be
+               * context for payg_system_poweroff() to have a chance to be
                * triggered.
                */
               g_main_context_iteration (NULL, FALSE);
@@ -538,13 +538,13 @@ main (int   argc,
           g_warning ("Provider failure, shutting down in %d minutes: %s",
                      TIMEOUT_POWEROFF_ON_ERROR_MINUTES, error->message);
           timeout_id = g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
-                                              payg_sync_and_poweroff, NULL);
+                                              payg_system_poweroff, NULL);
           ret = NO_PROVIDER_EXIT_CODE;
         }
       else if (g_error_matches (error, GSS_SERVICE_ERROR, GSS_SERVICE_ERROR_SIGNALLED))
         {
           /* The service received SIGTERM or SIGINT */
-          timeout_id = g_idle_add (payg_sync_and_poweroff, &timeout_id);
+          timeout_id = g_idle_add (payg_system_poweroff, &timeout_id);
           ret = FATAL_SIGNAL_EXIT_CODE;
         }
       else
@@ -562,8 +562,8 @@ main (int   argc,
 
   allow_writing_to_boot_partition (FALSE);
 
-  /* If payg_sync_and_poweroff is scheduled, spin the mainloop until it runs.
-   * timeout_id will be cleared by payg_sync_and_poweroff.
+  /* If payg_system_poweroff is scheduled, spin the mainloop until it runs.
+   * timeout_id will be cleared by payg_system_poweroff.
    */
   while (timeout_id)
     g_main_context_iteration (NULL, TRUE);

--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -35,6 +35,8 @@
 #include <sys/un.h>
 #include <libeos-payg/efi.h>
 
+#define TIMEOUT_POWEROFF_ON_ERROR_MINUTES 20
+
 #define FATAL_SIGNAL_EXIT_CODE 254
 #define WATCHDOG_FAILURE_EXIT_CODE 253
 #define SD_NOTIFY_FAILURE_EXIT_CODE 252
@@ -276,8 +278,10 @@ main (int   argc,
 
       if (!eospayg_efi_init (0))
         {
-          g_warning ("Unable to access EFI variables, shutting down in 20 minutes.");
-          g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
+          g_warning ("Unable to access EFI variables, shutting down in %d minutes",
+                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
+          g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
+                                 payg_sync_and_poweroff, NULL);
         }
 
       payg_set_debug_env_vars ();
@@ -311,15 +315,19 @@ main (int   argc,
       if (enforcing_mode && payg_should_check_securitylevel () &&
           !test_and_update_securitylevel ())
         {
-          g_warning ("Security level regressed, forced shutdown will occur in 20 minutes.");
-          g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
+          g_warning ("Security level regressed, shutting down in %d minutes",
+                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
+          g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
+                                 payg_sync_and_poweroff, NULL);
         }
 
       /* Setup RTC updater before the root pivot */
       if (enforcing_mode && !payg_hwclock_init ())
         {
-          g_warning ("RTC failure, forced shutdown will occur in 20 minutes.");
-          g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
+          g_warning ("RTC failure, shutting down in %d minutes",
+                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
+          g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
+                                 payg_sync_and_poweroff, NULL);
         }
     }
   else
@@ -446,7 +454,8 @@ main (int   argc,
        * loop; in the past we've had long running operations like migrations of
        * flatpaks occur during a reboot. */
       g_debug ("Attempting to connect to D-Bus daemon");
-      timeout_id = g_timeout_add_seconds (20 * 60, payg_sync_and_poweroff, NULL);
+      timeout_id = g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
+                                          payg_sync_and_poweroff, NULL);
       while (TRUE)
         {
           g_autoptr(GDBusConnection) bus_connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
@@ -523,11 +532,13 @@ main (int   argc,
     {
       if (g_error_matches (error, EPG_SERVICE_ERROR, EPG_SERVICE_ERROR_NO_PROVIDER))
         {
-          /* This could mean the PAYG data has been erased; force a poweroff
-           * after 10 minutes. See https://phabricator.endlessm.com/T27581
+          /* This could mean the PAYG data has been erased; force a poweroff.
+           * See https://phabricator.endlessm.com/T27581
            */
-          g_warning ("Initiating 10 minute shutdown timer due to error: %s", error->message);
-          timeout_id = g_timeout_add_seconds (10 * 60, payg_sync_and_poweroff, NULL);
+          g_warning ("Provider failure, shutting down in %d minutes: %s",
+                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES, error->message);
+          timeout_id = g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
+                                              payg_sync_and_poweroff, NULL);
           ret = NO_PROVIDER_EXIT_CODE;
         }
       else if (g_error_matches (error, GSS_SERVICE_ERROR, GSS_SERVICE_ERROR_SIGNALLED))

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -400,7 +400,7 @@ expired_cb (EpgProvider *provider,
       self->shutdown_timer_id =
               g_timeout_add_seconds_full (G_PRIORITY_HIGH,
                                           TIMEOUT_POWEROFF_NO_CREDIT_MINUTES * 60,
-                                          payg_sync_and_poweroff,
+                                          payg_system_poweroff,
                                           NULL, NULL);
       g_assert (self->shutdown_timer_id > 0);
 

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -28,6 +28,7 @@
 #include <libeos-payg/manager-service.h>
 #include <libeos-payg/util.h>
 
+#define TIMEOUT_POWEROFF_NO_CREDIT_MINUTES 10
 
 static void epg_manager_service_dispose      (GObject      *object);
 static void epg_manager_service_get_property (GObject      *object,
@@ -394,8 +395,13 @@ expired_cb (EpgProvider *provider,
        * long without credit. We could use epg_boottime_source_new() here but
        * presumably a suspended computer isn't very useful anyway.
        */
-      g_message ("Starting 10 minute shutdown timer due to expired PAYG credit");
-      self->shutdown_timer_id = g_timeout_add_seconds_full (G_PRIORITY_HIGH, 60 * 10, payg_sync_and_poweroff, NULL, NULL);
+      g_message ("Credit expired, shutting down in %d minutes",
+                 TIMEOUT_POWEROFF_NO_CREDIT_MINUTES);
+      self->shutdown_timer_id =
+              g_timeout_add_seconds_full (G_PRIORITY_HIGH,
+                                          TIMEOUT_POWEROFF_NO_CREDIT_MINUTES * 60,
+                                          payg_sync_and_poweroff,
+                                          NULL, NULL);
       g_assert (self->shutdown_timer_id > 0);
 
       g_clear_error (&local_error);

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -30,11 +30,19 @@ static gboolean payg_legacy_mode = FALSE;
 
 /* Force a poweroff in situations where we are not able to enforce PAYG. This
  * is intended to be used as a GSourceFunc, e.g. with g_timeout_add_seconds()
+ *
+ * If user_data != NULL, it must be a pointer to the source ID to be cleared.
  */
-__attribute__ ((__noreturn__)) gboolean
+gboolean
 payg_sync_and_poweroff (gpointer user_data)
 {
   int ret;
+
+  if (user_data != NULL)
+    {
+      guint *source_id = (guint *) user_data;
+      *source_id = 0;
+    }
 
   g_message ("Requesting an orderly system shudown");
   ret = system ("systemctl poweroff");
@@ -47,7 +55,7 @@ payg_sync_and_poweroff (gpointer user_data)
    * terminate. If an orderly system shutdown does not happen after we exit the
    * watchdog will take care of powering off the machine eventually.
    */
-  exit (EXIT_FAILURE);
+  return G_SOURCE_REMOVE;
 }
 
 /**

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -34,19 +34,18 @@ static gboolean payg_legacy_mode = FALSE;
 __attribute__ ((__noreturn__)) gboolean
 payg_sync_and_poweroff (gpointer user_data)
 {
-  g_message ("bcsn: Forcing poweroff now!");
-  if (system ("systemctl poweroff") != 0)
-    {
-      /* If we're here, something went wrong in the call, so we can force
-       * an immediate dirty shutdown, since we know a clean shutdown has
-       * already failed.
-       */
-      sync ();
-      reboot (LINUX_REBOOT_CMD_POWER_OFF);
-    }
-  /* We've requested a shutdown, so there's nothing left for us to do.
-   * Exit now so the watchdog timer will make sure we get our shutdown
-   * eventually.
+  int ret;
+
+  g_message ("Requesting an orderly system shudown");
+  ret = system ("systemctl poweroff");
+  g_debug ("systemctl returned %d", ret);
+
+  /* We have requested an orderly system shutdown. If that request failed or if
+   * a shutdown was already in progress 'systemctl' will return a failure
+   * status the same way, so we can't easily distinguish between these two
+   * scenarios. Let's ignore systemctl exit status and let the daemon
+   * terminate. If an orderly system shutdown does not happen after we exit the
+   * watchdog will take care of powering off the machine eventually.
    */
   exit (EXIT_FAILURE);
 }

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -34,7 +34,7 @@ static gboolean payg_legacy_mode = FALSE;
  * If user_data != NULL, it must be a pointer to the source ID to be cleared.
  */
 gboolean
-payg_sync_and_poweroff (gpointer user_data)
+payg_system_poweroff (gpointer user_data)
 {
   int ret;
 

--- a/libeos-payg/util.h
+++ b/libeos-payg/util.h
@@ -23,7 +23,7 @@
 
 G_BEGIN_DECLS
 
-gboolean payg_sync_and_poweroff (gpointer user_data);
+gboolean payg_system_poweroff (gpointer user_data);
 void payg_set_debug_env_vars (void);
 gboolean payg_get_secure_boot_enabled (void);
 gboolean payg_get_eospayg_active_set (void);


### PR DESCRIPTION
If the daemon receives one of these termination signals we should
trigger a poweroff, so the computer does not continue to run without
paygd.

This is required for us to allow the daemon to be terminated by systemd
during shutdown but not manually by the user.

https://phabricator.endlessm.com/T33088
https://phabricator.endlessm.com/T32815