### PR TITLE
paygd: Request poweroff if the service exits with any error

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -537,9 +537,7 @@ main (int   argc,
         }
       else if (g_error_matches (error, EPG_SERVICE_ERROR, EPG_SERVICE_ERROR_NO_PROVIDER))
         {
-          /* This could mean the PAYG data has been erased; force a poweroff.
-           * See https://phabricator.endlessm.com/T27581
-           */
+          /* This could mean the PAYG data has been erased; force a poweroff. */
           g_warning ("Provider failure, shutting down in %d minutes: %s",
                      TIMEOUT_POWEROFF_ON_ERROR_MINUTES, error->message);
           timeout_id = g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,


### PR DESCRIPTION
Handle all cases where the service object exits with an error by
requesting a poweroff after 20 minutes. The causes we expect to trigger
this logic are the provider data being errased or damaged, or paygd
losing the bus name (which can happen if the D-Bus server gets
terminated or restarted).

https://phabricator.endlessm.com/T33037