### PR TITLE
Create CodeLength D-Bus property

### DIFF
--- a/libeos-payg/manager-interface.h
+++ b/libeos-payg/manager-interface.h
@@ -181,6 +181,15 @@ static const GDBusPropertyInfo manager_interface_code_format_suffix =
   NULL,  /* annotations */
 };
 
+static const GDBusPropertyInfo manager_interface_code_length =
+{
+  -1,  /* ref count */
+  (gchar *) "CodeLength",
+  (gchar *) "u", /* Note: the special value 0 means the length was not specified */
+  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
+  NULL,  /* annotations */
+};
+
 static const GDBusPropertyInfo manager_interface_account_id =
 {
   -1,  /* ref count */
@@ -198,6 +207,7 @@ static const GDBusPropertyInfo *manager_interface_properties[] =
   &manager_interface_code_format,
   &manager_interface_code_format_prefix,
   &manager_interface_code_format_suffix,
+  &manager_interface_code_length,
   &manager_interface_account_id,
   NULL,
 };

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -993,7 +993,7 @@ epg_manager_service_manager_get_code_length (EpgManagerService     *self,
                                              const gchar           *property_name,
                                              GDBusMethodInvocation *invocation)
 {
-  return g_variant_new_uint32 (0);
+  return g_variant_new_uint32 (epg_provider_get_code_length (self->provider));
 }
 
 static GVariant *

--- a/libeos-payg/manager-service.c
+++ b/libeos-payg/manager-service.c
@@ -130,6 +130,14 @@ static GVariant *epg_manager_service_manager_get_code_format_suffix (EpgManagerS
                                                                      const gchar           *interface_name,
                                                                      const gchar           *property_name,
                                                                      GDBusMethodInvocation *invocation);
+
+static GVariant *epg_manager_service_manager_get_code_length (EpgManagerService     *self,
+                                                              GDBusConnection       *connection,
+                                                              const gchar           *sender,
+                                                              const gchar           *interface_name,
+                                                              const gchar           *property_name,
+                                                              GDBusMethodInvocation *invocation);
+
 static GVariant *epg_manager_service_manager_get_account_id (EpgManagerService     *self,
                                                              GDBusConnection       *connection,
                                                              const gchar           *sender,
@@ -676,6 +684,8 @@ manager_properties[] =
       epg_manager_service_manager_get_code_format_prefix, NULL  /* read-only */ },
     { "com.endlessm.Payg1", "CodeFormatSuffix", "code-format-suffix",
       epg_manager_service_manager_get_code_format_suffix, NULL  /* read-only */ },
+    { "com.endlessm.Payg1", "CodeLength", "code-ui-string",
+      epg_manager_service_manager_get_code_length, NULL  /* read-only */ },
     { "com.endlessm.Payg1", "AccountID", "account-id",
       epg_manager_service_manager_get_account_id, NULL  /* read-only */ },
   };
@@ -973,6 +983,17 @@ epg_manager_service_manager_get_code_format_suffix (EpgManagerService     *self,
                                                     GDBusMethodInvocation *invocation)
 {
   return g_variant_new_string (epg_provider_get_code_format_suffix (self->provider));
+}
+
+static GVariant *
+epg_manager_service_manager_get_code_length (EpgManagerService     *self,
+                                             GDBusConnection       *connection,
+                                             const gchar           *sender,
+                                             const gchar           *interface_name,
+                                             const gchar           *property_name,
+                                             GDBusMethodInvocation *invocation)
+{
+  return g_variant_new_uint32 (0);
 }
 
 static GVariant *

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -257,7 +257,7 @@ epg_manager_class_init (EpgManagerClass *klass)
    * A system-wide path is used if this property is not specified or is %NULL.
    * Only unit tests should need to override this path.
    *
-   * Since: 0.2.0
+   * Since: 0.2.4
    */
   props[PROP_ACCOUNT_ID_FILE] =
       g_param_spec_object ("account-id-file", "Account ID File",

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -191,6 +191,7 @@ typedef enum
   PROP_CODE_FORMAT,
   PROP_CODE_FORMAT_PREFIX,
   PROP_CODE_FORMAT_SUFFIX,
+  PROP_CODE_LENGTH,
   PROP_CLOCK,
   PROP_ACCOUNT_ID,
 } EpgManagerProperty;
@@ -220,6 +221,7 @@ epg_manager_class_init (EpgManagerClass *klass)
   g_object_class_override_property (object_class, PROP_CODE_FORMAT, "code-format");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
+  g_object_class_override_property (object_class, PROP_CODE_LENGTH, "code-length");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
   g_object_class_override_property (object_class, PROP_ACCOUNT_ID, "account-id");
 
@@ -315,6 +317,7 @@ epg_manager_provider_iface_init (gpointer g_iface,
   iface->code_format = "^[0-9]{8}$";
   iface->code_format_prefix = "";
   iface->code_format_suffix = "";
+  iface->code_length = 8;
 }
 
 static void
@@ -438,6 +441,9 @@ epg_manager_get_property (GObject    *object,
     case PROP_CODE_FORMAT_SUFFIX:
       g_value_set_static_string (value, epg_provider_get_code_format_suffix (provider));
       break;
+    case PROP_CODE_LENGTH:
+      g_value_set_uint (value, epg_provider_get_code_length (provider));
+      break;
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
@@ -464,6 +470,7 @@ epg_manager_set_property (GObject      *object,
     case PROP_CODE_FORMAT:
     case PROP_CODE_FORMAT_PREFIX:
     case PROP_CODE_FORMAT_SUFFIX:
+    case PROP_CODE_LENGTH:
     case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -155,6 +155,24 @@ epg_provider_default_init (EpgProviderInterface *iface)
   g_object_interface_install_property (iface, pspec);
 
   /**
+   * EpgProvider:code-length:
+   *
+   * The length of an unlock code, in Unicode characters.
+   *
+   * This property is constant once the provider is initialized.
+   *
+   * A value of 0 means the length was not specified by the provider.
+   *
+   * Since: 0.2.4
+   */
+  pspec =
+      g_param_spec_uint ("code-length", "Code Length",
+                         "The length of an unlock code, in Unicode characters.",
+                         0, G_MAXUINT32, 0,
+                         G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+  g_object_interface_install_property (iface, pspec);
+
+  /**
    * EpgProvider:clock:
    *
    * Clock used to get the time and create timeout #GSource objects.
@@ -504,6 +522,28 @@ epg_provider_get_code_format_suffix (EpgProvider *self)
     return iface->code_format_suffix;
 
   return "";
+}
+
+/**
+ * epg_provider_get_code_length:
+ * @self: a #EpgProvider
+ *
+ * Get the value of #EpgProvider:code-length
+ *
+ * Returns: the value to be used by the UI when referring to the unlock code
+ * length, in Unicode characters. A value of 0 means the UI should not mention
+ * the unlock code length as the provider may support codes of different
+ * lengths.
+ * Since: 0.2.4
+ */
+guint32
+epg_provider_get_code_length (EpgProvider *self)
+{
+  g_return_val_if_fail (EPG_IS_PROVIDER (self), 0);
+
+  EpgProviderInterface *iface = EPG_PROVIDER_GET_IFACE (self);
+
+  return iface->code_length;
 }
 
 /**

--- a/libeos-payg/provider.h
+++ b/libeos-payg/provider.h
@@ -61,6 +61,7 @@ struct _EpgProviderInterface
   const gchar *     code_format;
   const gchar *     code_format_prefix;
   const gchar *     code_format_suffix;
+  guint32           code_length;
 };
 
 gboolean        epg_provider_add_code   (EpgProvider  *self,
@@ -87,6 +88,7 @@ guint64         epg_provider_get_rate_limit_end_time (EpgProvider *self);
 const gchar *   epg_provider_get_code_format         (EpgProvider *self);
 const gchar *   epg_provider_get_code_format_prefix  (EpgProvider *self);
 const gchar *   epg_provider_get_code_format_suffix  (EpgProvider *self);
+guint32         epg_provider_get_code_length         (EpgProvider *self);
 EpgClock *      epg_provider_get_clock               (EpgProvider *self);
 const gchar *   epg_provider_get_account_id          (EpgProvider *self);
 

--- a/libeos-payg/tests/manager.c
+++ b/libeos-payg/tests/manager.c
@@ -316,6 +316,21 @@ test_manager_code_format_suffix (Fixture *fixture,
   g_assert_cmpstr (code_format_suffix, ==, "");
 }
 
+/* test_code_format_suffix:
+ *
+ * Tests that the :code-length is properly returned.
+ */
+static void
+test_manager_code_length (Fixture *fixture,
+                          gconstpointer data)
+{
+  manager_new (fixture);
+
+  guint32 code_length = epg_provider_get_code_length (fixture->provider);
+
+  g_assert_cmpuint (code_length, ==, 8);
+}
+
 /* test_manager_code_format_matches:
  * @data: const gchar *
  *
@@ -910,6 +925,7 @@ main (int    argc,
   T ("/manager/add-infinite", test_manager_add_infinite_code, NULL);
   T ("/manager/get-code-format-prefix", test_manager_code_format_prefix, NULL);
   T ("/manager/get-code-format-suffix", test_manager_code_format_suffix, NULL);
+  T ("/manager/get-code-length", test_manager_code_length, NULL);
   T ("/manager/get-account-id-missing", test_manager_account_id,
      GUINT_TO_POINTER (0));
   T ("/manager/get-account-id-present", test_manager_account_id,

--- a/libeos-payg/tests/plugins/test-provider.c
+++ b/libeos-payg/tests/plugins/test-provider.c
@@ -80,6 +80,7 @@ typedef enum
   PROP_CODE_FORMAT,
   PROP_CODE_FORMAT_PREFIX,
   PROP_CODE_FORMAT_SUFFIX,
+  PROP_CODE_LENGTH,
   PROP_CLOCK,
   PROP_ACCOUNT_ID,
 } EpgTestProviderProperty;
@@ -107,6 +108,7 @@ epg_test_provider_class_init (EpgTestProviderClass *klass)
   g_object_class_override_property (object_class, PROP_CODE_FORMAT, "code-format");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_PREFIX, "code-format-prefix");
   g_object_class_override_property (object_class, PROP_CODE_FORMAT_SUFFIX, "code-format-suffix");
+  g_object_class_override_property (object_class, PROP_CODE_LENGTH, "code-length");
   g_object_class_override_property (object_class, PROP_CLOCK, "clock");
   g_object_class_override_property (object_class, PROP_ACCOUNT_ID, "account-id");
 }
@@ -139,6 +141,7 @@ epg_test_provider_provider_iface_init (gpointer g_iface,
   iface->code_format = "";
   iface->code_format_prefix = "";
   iface->code_format_suffix = "";
+  iface->code_length = 0;
 }
 
 static void
@@ -175,6 +178,9 @@ epg_test_provider_get_property (GObject    *object,
     case PROP_CODE_FORMAT_SUFFIX:
       g_value_set_static_string (value, epg_provider_get_code_format_suffix (provider));
       break;
+    case PROP_CODE_LENGTH:
+      g_value_set_uint (value, epg_provider_get_code_length (provider));
+      break;
     case PROP_CLOCK:
       g_value_set_object (value, epg_provider_get_clock (provider));
       break;
@@ -202,6 +208,7 @@ epg_test_provider_set_property (GObject      *object,
     case PROP_CODE_FORMAT:
     case PROP_CODE_FORMAT_PREFIX:
     case PROP_CODE_FORMAT_SUFFIX:
+    case PROP_CODE_LENGTH:
     case PROP_ACCOUNT_ID:
       /* Read only. */
       g_assert_not_reached ();

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('eos-payg','c',
-  version: '0.2.2',
+  version: '0.2.4',
   meson_version: '>= 0.50.0',
   license: 'MPL-2.0 or LGPLv2.1+',
   default_options: [


### PR DESCRIPTION
Create a new CodeUIString read-only D-Bus property that will be used by
providers to inform the UI on how their unlock codes should be referred
to.

This also overrides its value in EpgManager with 8.

https://phabricator.endlessm.com/T33325