### PR TITLE
provision-phase-1: Update git submodules before building

### DIFF
--- a/provision-phase-1/Jenkinsfile
+++ b/provision-phase-1/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                sh 'git submodule update'
                 sh 'meson . build'
 
                 // Just build the tarballs and sha256 files


### PR DESCRIPTION
Even if we are not actually building any submodules when generating the
tarballs, we need the tree to be present during meson configuration.

https://phabricator.endlessm.com/T33373