### PR TITLE
paygd: Write logs to a separate file

### DIFF
--- a/debian/eos-paygd.install
+++ b/debian/eos-paygd.install
@@ -1,5 +1,6 @@
 lib/systemd/system/eos-paygd.service
 lib/systemd/system/eos-paygd-2.service
+usr/lib/tmpfiles.d/eos-paygd.conf
 usr/lib/*/eos-payg-1/libeos-payg-1.so
 usr/lib/*/eos-paygd1
 usr/share/dbus-1/system.d/com.endlessm.Payg1.conf

--- a/eos-paygd/eos-paygd.tmpfile
+++ b/eos-paygd/eos-paygd.tmpfile
@@ -1,0 +1,6 @@
+# Create logs directory for eos-paygd. Files in this directory that were not
+# created, modified or accessed in the last 90 days will be removed by
+# systemd-tmpfiles cleanup service.
+#
+# TODO: Once we update systemd to 249+, replace the age field below with m:90d
+d /var/log/eos-payg 0755 root root 90d

--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -36,6 +36,10 @@ systemdsystemunitdir = get_option('systemdsystemunitdir')
 if systemdsystemunitdir == ''
   systemdsystemunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
 endif
+tmpfilesdir = get_option('tmpfilesdir')
+if tmpfilesdir == ''
+  tmpfilesdir = systemd.get_pkgconfig_variable('tmpfilesdir')
+endif
 
 # eos-paygd service for Phase 2 PAYG systems
 configure_file(
@@ -50,6 +54,12 @@ configure_file(
   output: 'eos-paygd-2.service',
   install_dir: systemdsystemunitdir,
   configuration: config,
+)
+# eos-paygd tmpfile for maintaining logs directory
+install_data(
+  'eos-paygd.tmpfile',
+  rename: 'eos-paygd.conf',
+  install_dir: tmpfilesdir,
 )
 
 # Documentation

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,3 +19,7 @@ option('sysusersdir',
   description: 'the directory to install sysusers files to (default: looked up with pkgconfig)',
   type: 'string',
 )
+option('tmpfilesdir',
+  description: 'the directory to install tmpfiles to (default: looked up with pkgconfig)',
+  type: 'string'
+)


### PR DESCRIPTION
In systems with fragile storage (ex., SSD or eMMC) the journal is only
kept in RAM as does not persist over reboot. In such systems we still
want logs from eos-paygd to persist, without having to write all system
logs to persistent storage.

The solution for that is to create a separate log file for eos-paygd, in
addition to forwarding logs to the journal.

https://phabricator.endlessm.com/T33220