### PR TITLE
service: Pass current time to provider on clock jumps

### DIFF
--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -81,7 +81,8 @@ static gboolean    epg_manager_shutdown_finish (EpgProvider          *provider,
                                                 GError              **error);
 
 static void        epg_manager_wallclock_time_changed (EpgProvider *provider,
-                                                       gint64       delta);
+                                                       gint64       delta,
+                                                       gint64       now_secs);
 
 static void        internal_save_state_cb (GObject      *source_object,
                                            GAsyncResult *result,
@@ -1685,7 +1686,8 @@ epg_manager_shutdown_finish (EpgProvider   *provider,
 
 static void
 epg_manager_wallclock_time_changed (EpgProvider *provider,
-                                    gint64       delta)
+                                    gint64       delta,
+                                    gint64       now_secs)
 {
   EpgManager *self = EPG_MANAGER (provider);
 
@@ -1698,8 +1700,6 @@ epg_manager_wallclock_time_changed (EpgProvider *provider,
    * miscalculated the consumption of credit at startup. */
   if (delta > 0)
     {
-      guint64 now_secs = epg_clock_get_time (self->clock);
-
       /* FIXME: This actually extends the expiration rather than reducing it
        * but the Endless backend is basically deprecated anyway in favor of
        * Angaza.

--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -383,7 +383,8 @@ epg_provider_shutdown_finish (EpgProvider   *self,
  */
 void
 epg_provider_wallclock_time_changed (EpgProvider   *self,
-                                     gint64         delta)
+                                     gint64         delta,
+                                     gint64         now_secs)
 {
   g_return_if_fail (EPG_IS_PROVIDER (self));
 
@@ -391,7 +392,7 @@ epg_provider_wallclock_time_changed (EpgProvider   *self,
 
   g_assert (iface->wallclock_time_changed != NULL);
 
-  return iface->wallclock_time_changed (self, delta);
+  return iface->wallclock_time_changed (self, delta, now_secs);
 }
 
 /**

--- a/libeos-payg/provider.h
+++ b/libeos-payg/provider.h
@@ -50,7 +50,8 @@ struct _EpgProviderInterface
                                       GError       **error);
 
   void            (*wallclock_time_changed)  (EpgProvider *self,
-                                              gint64       delta);
+                                              gint64       delta,
+                                              gint64       now_secs);
 
   guint64         (*get_expiry_time)         (EpgProvider *self);
   gboolean        (*get_enabled)             (EpgProvider *self);
@@ -80,7 +81,8 @@ gboolean        epg_provider_shutdown_finish (EpgProvider   *self,
                                               GError       **error);
 
 void            epg_provider_wallclock_time_changed  (EpgProvider *self,
-                                                      gint64       delta);
+                                                      gint64       delta,
+                                                      gint64       now_secs);
 
 guint64         epg_provider_get_expiry_time         (EpgProvider *self);
 gboolean        epg_provider_get_enabled             (EpgProvider *self);

--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -241,7 +241,7 @@ clock_jump_cb (gpointer user_data)
   if (clock_jump_delta != 0)
     {
       g_message ("Detected system clock jump of %" G_GINT64_FORMAT " seconds", clock_jump_delta);
-      epg_provider_wallclock_time_changed (self->provider, clock_jump_delta);
+      epg_provider_wallclock_time_changed (self->provider, clock_jump_delta, clock_realtime_secs_v1);
     }
 
   self->clock_realtime_secs_v0 = clock_realtime_secs_v1;


### PR DESCRIPTION
When a clock jump is detected, we already need to get the current wallclock time to calculate the jump size. Let's pass this information to the provider, so it can better decide how to handle the jump.

Also update the "manager" provider to use the time passed by caller in its wallclock_time_changed implementation instead of calculating again.

https://phabricator.endlessm.com/T33873