### PR TITLE
provider: Document now_sec on epg_provider_shutdown_finish

### DIFF
--- a/libeos-payg/provider.c
+++ b/libeos-payg/provider.c
@@ -375,6 +375,8 @@ epg_provider_shutdown_finish (EpgProvider   *self,
  * @self: an #EpgProvider
  * @delta: the amount by which the clock changed in seconds, which can be
  * positive or negative
+ * @now_secs: the new time (from CLOCK_REALTIME) after the clock jump, in unix
+ * seconds
  *
  * Notify the provider of a discontinous change to the system clock (e.g. by
  * the user or by NTP) so state can be saved if necessary.


### PR DESCRIPTION
This parameter was added a few commits ago, but the documentation was missed.