### PR TITLE
Support 31-day codes

### DIFF
--- a/eos-payg-generate/main.c
+++ b/eos-payg-generate/main.c
@@ -67,6 +67,7 @@ periods[] =
     { EPC_PERIOD_13_DAYS, "13d", N_("13 days") },
     { EPC_PERIOD_14_DAYS, "14d", N_("14 days") },
     { EPC_PERIOD_30_DAYS, "30d", N_("30 days") },
+    { EPC_PERIOD_31_DAYS, "31d", N_("31 days") },
     { EPC_PERIOD_60_DAYS, "60d", N_("60 days") },
     { EPC_PERIOD_90_DAYS, "90d", N_("90 days") },
     { EPC_PERIOD_120_DAYS, "120d", N_("120 days") },

--- a/libeos-payg-codes/codes.c
+++ b/libeos-payg-codes/codes.c
@@ -123,6 +123,7 @@ epc_period_validate (EpcPeriod   period,
     case EPC_PERIOD_13_DAYS:
     case EPC_PERIOD_14_DAYS:
     case EPC_PERIOD_30_DAYS:
+    case EPC_PERIOD_31_DAYS:
     case EPC_PERIOD_60_DAYS:
     case EPC_PERIOD_90_DAYS:
     case EPC_PERIOD_120_DAYS:

--- a/libeos-payg-codes/codes.h
+++ b/libeos-payg-codes/codes.h
@@ -91,6 +91,7 @@ typedef enum
   EPC_PERIOD_365_DAYS = 22,
   EPC_PERIOD_30_MINUTES = 23,
   EPC_PERIOD_8_HOURS = 24,
+  EPC_PERIOD_31_DAYS = 25,
   /* add additional periods here, and update %EPC_N_PERIODS */
   EPC_PERIOD_INFINITE = 31,
   /* This must use 5 bits exactly, so no values above 31 are allowed */
@@ -103,7 +104,7 @@ typedef enum
  *
  * Since: 0.1.0
  */
-#define EPC_N_PERIODS 26
+#define EPC_N_PERIODS 27
 
 gboolean epc_period_validate (EpcPeriod   period,
                               GError    **error);

--- a/libeos-payg-codes/tests/codes.c
+++ b/libeos-payg-codes/tests/codes.c
@@ -123,6 +123,7 @@ test_codes_calculate_round_trip (void)
       { EPC_PERIOD_13_DAYS, 76, key1, 34178837 },
       { EPC_PERIOD_14_DAYS, 66, key1, 36195098 },
       { EPC_PERIOD_30_DAYS, 70, key1, 38323642 },
+      { EPC_PERIOD_31_DAYS, 33, key1, 52704144 },
       { EPC_PERIOD_60_DAYS, 64, key1, 40373693 },
       { EPC_PERIOD_90_DAYS, 95, key1, 42722623 },
       { EPC_PERIOD_120_DAYS, 43, key1, 44396753 },

--- a/libeos-payg/manager.c
+++ b/libeos-payg/manager.c
@@ -873,6 +873,9 @@ extend_expiry_time (EpgManager *self,
     case EPC_PERIOD_30_DAYS:
       span_secs = 30 * 24 * 60 * 60;
       break;
+    case EPC_PERIOD_31_DAYS:
+      span_secs = 31 * 24 * 60 * 60;
+      break;
     case EPC_PERIOD_60_DAYS:
       span_secs = 60 * 24 * 60 * 60;
       break;


### PR DESCRIPTION
Paying on the same calendar day each month is predictable and standard
for other subscription models. But previously, doing this would either
mean issuing two codes in months with 31 days (one for 30 days, another
for 1 day) or the user running out of credit for a day.

By supporting 31-day codes, it is possible to either issue a 30-day or
31-day code depending on the month, or (more likely) to simply issue a
31-day code every month, leaving the user with 7-8 days' extra credit at
the end of each year.

(We could in principle add 28-day and 29-day codes to support February
and lunar calendars "natively", but there are only 5 more bits available
in this bitfield.)

https://phabricator.endlessm.com/T33556
