### PR TITLE
Fix NUL bytes in Python test output

### DIFF
--- a/dracut/meson.build
+++ b/dracut/meson.build
@@ -1,5 +1,5 @@
 dracut = dependency('dracut', required: true)
-dracut_moddir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50eos-payg'
+dracut_moddir = dracut.get_variable(pkgconfig: 'dracutmodulesdir') + '/50eos-payg'
 
 config = configuration_data()
 config.set('libexecdir', join_paths(get_option('prefix'), get_option('libexecdir')))

--- a/eos-payg-csv/tests/meson.build
+++ b/eos-payg-csv/tests/meson.build
@@ -49,5 +49,6 @@ foreach program: test_programs
     args: main,
     env: envs,
     suite: ['eos-payg'],
+    protocol: 'tap',
   )
 endforeach

--- a/eos-payg-csv/tests/taptestrunner.py
+++ b/eos-payg-csv/tests/taptestrunner.py
@@ -125,6 +125,7 @@ class TAPTestResult(unittest.TestResult):
           else:
             self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
         log.truncate(0)
+        log.seek(0)
 
   def addSuccess(self, test):
     super(TAPTestResult, self).addSuccess(test)

--- a/eos-payg-generate/tests/meson.build
+++ b/eos-payg-generate/tests/meson.build
@@ -44,5 +44,6 @@ foreach program: test_programs
     args: main,
     env: envs,
     suite: ['eos-payg'],
+    protocol: 'tap',
   )
 endforeach

--- a/eos-payg-generate/tests/taptestrunner.py
+++ b/eos-payg-generate/tests/taptestrunner.py
@@ -125,6 +125,7 @@ class TAPTestResult(unittest.TestResult):
           else:
             self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
         log.truncate(0)
+        log.seek(0)
 
   def addSuccess(self, test):
     super(TAPTestResult, self).addSuccess(test)

--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -34,11 +34,11 @@ configure_file(
 systemd = dependency('systemd')
 systemdsystemunitdir = get_option('systemdsystemunitdir')
 if systemdsystemunitdir == ''
-  systemdsystemunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+  systemdsystemunitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 endif
 tmpfilesdir = get_option('tmpfilesdir')
 if tmpfilesdir == ''
-  tmpfilesdir = systemd.get_pkgconfig_variable('tmpfilesdir')
+  tmpfilesdir = systemd.get_variable(pkgconfig: 'tmpfilesdir')
 endif
 
 # eos-paygd service for Phase 2 PAYG systems

--- a/libeos-payg-codes/tests/meson.build
+++ b/libeos-payg-codes/tests/meson.build
@@ -46,5 +46,6 @@ foreach program: test_programs
     exe,
     env: envs,
     suite: ['eos-payg'],
+    protocol: 'tap',
   )
 endforeach

--- a/libeos-payg/tests/meson.build
+++ b/libeos-payg/tests/meson.build
@@ -59,6 +59,7 @@ foreach program_name, extra_args : test_programs
       exe,
       env: envs,
       suite: ['eos-payg'] + suites,
+      protocol: 'tap',
     )
   endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('eos-payg','c',
   version: '0.2.4',
-  meson_version: '>= 0.50.0',
+  meson_version: '>= 0.51.0',
   license: 'MPL-2.0 or LGPLv2.1+',
   default_options: [
     # We want all internal libraries, including libgsystemservice, to be


### PR DESCRIPTION
This was a bug in the copy-pasted TAP test runner, which I have fixed upstream & applied here.

https://phabricator.endlessm.com/T34768