### PR TITLE
Partially revert "tests: Tell Meson our tests emit TAP output"

### DIFF
--- a/libeos-payg-codes/tests/meson.build
+++ b/libeos-payg-codes/tests/meson.build
@@ -46,6 +46,5 @@ foreach program: test_programs
     exe,
     env: envs,
     suite: ['eos-payg'],
-    protocol: 'tap',
   )
 endforeach

--- a/libeos-payg/tests/meson.build
+++ b/libeos-payg/tests/meson.build
@@ -59,7 +59,6 @@ foreach program_name, extra_args : test_programs
       exe,
       env: envs,
       suite: ['eos-payg'] + suites,
-      protocol: 'tap',
     )
   endif
 endforeach


### PR DESCRIPTION
This reverts the hunks of 15f0d9319f29c56cdd345b67892013786084921b
which affect the tests written in C, as opposed to the Python ones.

In my environment, this only showed a warning like:

    Unknown TAP version. The first line MUST be `TAP version <int>`. Assuming version 12.

but for JP there are many other errors:

     8/11 eos-payg:eos-payg / manager                      SKIP            0.11s
    Unknown TAP version. The first line MUST be `TAP version <int>`. Assuming version 12.
    stdout:  1: UNKNOWN: /manager/load-empty: OK
    [...]
    ERROR: Unknown TAP output lines for a supported TAP version.
    This is probably a bug in the test; if they are not TAP syntax, prefix them with a #

This is not essential. Revert.

https://phabricator.endlessm.com/T34768
