### PR TITLE
Build-depend on systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  libsystemd-dev,
  meson,
  python3-dbusmock,
+ systemd,
 
 Package: eos-paygd
 Section: misc

--- a/debian/control
+++ b/debian/control
@@ -7,13 +7,13 @@ X-Python3-Version: >= 3.7
 Build-Depends:
  debhelper (>= 10),
  dh-python,
+ dracut,
+ gtk-doc-tools,
  libglib2.0-dev (>= 2.54.2),
  libpeas-dev,
  libsystemd-dev,
  meson,
  python3-dbusmock,
- dracut,
- gtk-doc-tools,
 
 Package: eos-paygd
 Section: misc

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,10 +15,6 @@ option('systemdsystemunitdir',
   description: 'the directory to install systemd system units to (default: looked up with pkgconfig)',
   type: 'string'
 )
-option('sysusersdir',
-  description: 'the directory to install sysusers files to (default: looked up with pkgconfig)',
-  type: 'string',
-)
 option('tmpfilesdir',
   description: 'the directory to install tmpfiles to (default: looked up with pkgconfig)',
   type: 'string'


### PR DESCRIPTION
As described in the commit message, this is needed because two paths are looked up from `systemd.pc`. Evidently the `systemd` package is installed in the Jenkins build environment because 8f0ba1bf2427e4329369e60eefa54ce9773a35a2 builds fine on Jenkins; and evidently it is present in the OBS build environment on 5.1 because that same change built fine on `eos:5.1:endless`; but the build failed on `eos:master:endless`.

https://phabricator.endlessm.com/T35174