### PR TITLE
payg: Ignore access time when cleaning log files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Architecture: any
 Multi-arch: same
 Depends:
  eos-payg-data (= ${source:Version}),
- systemd (>= 235),
+ systemd (>= 249),
  dracut,
  ${misc:Depends},
  ${shlibs:Depends},

--- a/eos-paygd/eos-paygd.tmpfile
+++ b/eos-paygd/eos-paygd.tmpfile
@@ -1,6 +1,3 @@
 # Create logs directory for eos-paygd. Files in this directory that were not
-# created, modified or accessed in the last 90 days will be removed by
-# systemd-tmpfiles cleanup service.
-#
-# TODO: Once we update systemd to 249+, replace the age field below with m:90d
-d /var/log/eos-payg 0755 root root 90d
+# modified in the last 90 days will be removed by systemd-tmpfiles-clean.
+d /var/log/eos-payg 0755 root root m:90d


### PR DESCRIPTION
In commit acc43e1ed67e9a8ab8b56eef0b6084108e6e8c89, JP wrote:

> This will instruct systemd to remove any files that have not been
> created, modified or accessed in the last 90 days. Ideally we would have
> used 'm:90d' so just opening a file for reading would not interfere with
> its cleanup, but this is only supported on systemd 249+ and EOS 4.0.x
> ships systemd 247.

Endless OS 6 ships systemd 254, so we can now implement the TODO.

https://phabricator.endlessm.com/T35528
