### PR TITLE
efi: Simplify closing fds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "subprojects/libgsystemservice"]
 	path = subprojects/libgsystemservice
 	url = https://gitlab.gnome.org/pwithnall/libgsystemservice.git
+[submodule "subprojects/libglnx"]
+	path = subprojects/libglnx
+	url = https://gitlab.gnome.org/GNOME/libglnx

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -527,7 +527,8 @@ eospayg_efi_securebootoption_disabled (void)
  * space, but the kernel has a placeholder file for it due to a failed
  * write.
  *
- * Returns: size of the PK efi variable including EFI overhead, or -1 if missing
+ * Returns: size of the PK EFI variable, excluding the 4-byte attribute
+ *          overhead, or -1 if missing
  */
 int
 eospayg_efi_PK_size (void)

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -340,8 +340,7 @@ eospayg_efi_var_delete_fullname (const char *name)
  * operation. Notably, EBUSY will indicate that the deletion
  * probably failed due to the existence of a bind mount for
  * the file.
-
- * Returns: %TRUE if successsful, otherwise %FALSE
+ * Returns: %TRUE if successful, otherwise %FALSE
  */
 gboolean
 eospayg_efi_var_delete (const char *name)

--- a/libeos-payg/meson.build
+++ b/libeos-payg/meson.build
@@ -42,6 +42,7 @@ libeos_payg_deps = [
   dependency('libpeas-1.0'),
   libeos_payg_codes_dep,
   libgsystemservice_dep,
+  libglnx_dep,
 ]
 
 libeos_payg_resources = gnome.compile_resources(

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,8 @@ add_project_arguments(
   language: 'c',
 )
 
+libglnx_dep = subproject('libglnx').get_variable('libglnx_dep')
+
 subdir('libeos-payg-codes')
 subdir('libeos-payg')
 subdir('eos-paygd')


### PR DESCRIPTION
[libglnx](https://gitlab.gnome.org/GNOME/libglnx) is a helper library designed to be embedded into another project as a git submodule. Among other things, it provides an attribute you can attach to a variable holding a file descriptor, which calls `close()` on it when it goes out of scope if it is non-negative. Any error from `close()` is ignored, just like our existing code, except if it is `EBADF`, which indicates a programming error.

Add a libglnx submodule, and use `glnx_autofd` throughout our EFI code. Most cases are simple but `eospayg_efi_init()` is a little bit more involved.

This will make it easier to propagate errors to the caller in a future commit.

Additionally, fix a couple of errors in docstrings.

https://phabricator.endlessm.com/T35459