### PR TITLE
libeos-payg: Build libeos-payg as both shared & static libs

### DIFF
--- a/debian/libeos-payg-1-dev.install
+++ b/debian/libeos-payg-1-dev.install
@@ -1,3 +1,4 @@
+usr/lib/*/eos-payg-1/libeos-payg-1.a
 usr/lib/*/pkgconfig/eos-payg-1.pc
 usr/include/eos-payg-1/libeos-payg
 

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,8 @@ override_dh_auto_configure:
 	dh_auto_configure \
 		-- \
 		-Dinstalled_tests=true \
-		-Ddefault_library=static \
+		-Ddefault_library=both \
+		-Dlibgsystemservice:default_library=static \
 		-Dtests=unsafe
 		$(NULL)
 

--- a/libeos-payg/meson.build
+++ b/libeos-payg/meson.build
@@ -51,7 +51,7 @@ libeos_payg_resources = gnome.compile_resources(
   c_name : 'epg',
 )
 
-libeos_payg = shared_library(eos_payg_api_name,
+libeos_payg = library(eos_payg_api_name,
   libeos_payg_sources + libeos_payg_headers + libeos_payg_resources,
   dependencies: libeos_payg_deps,
   include_directories: root_inc,
@@ -68,10 +68,10 @@ install_headers(libeos_payg_exported_headers,
   subdir: libeos_payg_include_subdir,
 )
 
-# Can't use the shorthand where we pass the shared_library() as the first
-# argument to inherit its name because this also inherits its install_dir; but
-# we want the .pc file to end up in the standard pkgconfig path, not a
-# pkgconfig file inside pkglibdir (which will not be searched by pkg-config).
+# Can't use the shorthand where we pass the library() as the first argument to
+# inherit its name because this also inherits its install_dir; but we want the
+# .pc file to end up in the standard pkgconfig path, not a pkgconfig file inside
+# pkglibdir (which will not be searched by pkg-config).
 pkgconfig.generate(
   name: eos_payg_api_name,
   description: 'Pay-as-you-go support for Endless OS',


### PR DESCRIPTION
To build eos-payg-nonfree against libeos-payg static lib for avoiding API/ABI issue, build and install libeos-payg as both shared & static libs.

https://phabricator.endlessm.com/T35437