### PR TITLE
efi: Introduce eospayg_efi_setupmode()

### DIFF
--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -370,6 +370,7 @@ eospayg_efi_var_delete_fullname (const char  *name,
                                  GError     **error)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   /* Make sure we never delete a non EOSPAYG_
@@ -404,6 +405,7 @@ eospayg_efi_var_delete (const char  *name,
                         GError     **error)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   g_autofree char *tname = eospayg_efi_name (name);
@@ -445,6 +447,7 @@ gboolean
 eospayg_efi_var_exists (const char *name)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
 
   return efi->exists (name);
 }
@@ -689,6 +692,7 @@ eospayg_efi_var_read_fullname (const char  *name,
                                GError     **error)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
   g_return_val_if_fail (expected_size >= -1, FALSE);
   g_return_val_if_fail (size != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -727,6 +731,8 @@ eospayg_efi_var_read_fullname_boolean (const char  *name,
                                        GError     **error)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   g_autofree unsigned char *content = NULL;
   int size;
@@ -764,6 +770,10 @@ eospayg_efi_var_read (const char  *name,
                       GError     **error)
 {
   g_return_val_if_fail (efi != NULL, FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
+  g_return_val_if_fail (expected_size >= -1, FALSE);
+  g_return_val_if_fail (size != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   g_autofree char *tname = eospayg_efi_name (name);
 

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -370,6 +370,7 @@ gboolean
 eospayg_efi_var_delete_fullname (const char  *name,
                                  GError     **error)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   /* Make sure we never delete a non EOSPAYG_
@@ -403,6 +404,7 @@ gboolean
 eospayg_efi_var_delete (const char  *name,
                         GError     **error)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   g_autofree char *tname = eospayg_efi_name (name);
@@ -443,6 +445,8 @@ efivarfs_exists (const char *name)
 gboolean
 eospayg_efi_var_exists (const char *name)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   return efi->exists (name);
 }
 
@@ -549,6 +553,8 @@ eospayg_efi_secureboot_active (void)
   if (test_mode)
     return TRUE;
 
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SecureBoot");
 
   return eospayg_efi_var_read_fullname_boolean (name, NULL);
@@ -563,6 +569,8 @@ eospayg_efi_secureboot_active (void)
 gboolean
 eospayg_efi_setupmode_active (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SetupMode");
 
   return eospayg_efi_var_read_fullname_boolean (name, NULL);
@@ -582,6 +590,7 @@ eospayg_efi_setupmode_active (void)
 enum efivar_states
 eospayg_efi_secureboot_setup_active (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
   g_autofree char *name = full_efi_name (SECUREBOOT_SETUP_GUID,
                                          "SecureBootSetup");
   g_autoptr(GError) error = NULL;
@@ -613,6 +622,8 @@ eospayg_efi_secureboot_setup_active (void)
 gboolean
 eospayg_efi_securebootoption_disabled (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree char *tname = full_efi_name (SBO_VARIABLE_GUID, "SecureBootOption");
   g_autofree unsigned char *content = NULL;
   int size;
@@ -643,6 +654,8 @@ eospayg_efi_securebootoption_disabled (void)
 int
 eospayg_efi_PK_size (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree char *tname = full_efi_name (GLOBAL_VARIABLE_GUID, "PK");
   g_autofree unsigned char *content = NULL;
   int size;
@@ -676,6 +689,7 @@ eospayg_efi_var_read_fullname (const char  *name,
                                int         *size,
                                GError     **error)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
   g_return_val_if_fail (expected_size >= -1, FALSE);
   g_return_val_if_fail (size != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -713,6 +727,8 @@ gboolean
 eospayg_efi_var_read_fullname_boolean (const char  *name,
                                        GError     **error)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree unsigned char *content = NULL;
   int size;
 
@@ -748,6 +764,8 @@ eospayg_efi_var_read (const char  *name,
                       int         *size,
                       GError     **error)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   g_autofree char *tname = eospayg_efi_name (name);
 
   return eospayg_efi_var_read_fullname (tname, expected_size, size, error);
@@ -772,6 +790,8 @@ efivarfs_list_rewind (void)
 void
 eospayg_efi_list_rewind (void)
 {
+  g_return_if_fail (efi != NULL);
+
   efi->list_rewind ();
 }
 
@@ -815,6 +835,8 @@ efivarfs_list_next (void)
 const char *
 eospayg_efi_list_next (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   return efi->list_next ();
 }
 
@@ -839,8 +861,11 @@ test_clear (void)
  * Returns: %TRUE if all PAYG EFI variables could be cleared,
  *   %FALSE otherwise.
  */
-gboolean eospayg_efi_clear (void)
+gboolean
+eospayg_efi_clear (void)
 {
+  g_return_val_if_fail (efi != NULL, FALSE);
+
   if (!efi->clear)
     return FALSE;
 

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -645,11 +645,11 @@ eospayg_efi_var_read (const char  *name,
                       int         *size,
                       GError     **error)
 {
+  g_autofree char *tname = eospayg_efi_name (name);
+
   g_return_val_if_fail (expected_size >= -1, FALSE);
   g_return_val_if_fail (size != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-  g_autofree char *tname = eospayg_efi_name (name);
 
   *size = -1;
   if (post_pivot)

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -544,7 +544,7 @@ efivarfs_read (const char  *name,
 gboolean
 eospayg_efi_secureboot_active (void)
 {
-  g_autofree char *tname = full_efi_name (GLOBAL_VARIABLE_GUID, "SecureBoot");
+  g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SecureBoot");
   g_autofree unsigned char *content = NULL;
   int size;
 
@@ -552,7 +552,7 @@ eospayg_efi_secureboot_active (void)
   if (test_mode)
     return TRUE;
 
-  content = efivarfs_read (tname, &size, NULL);
+  content = eospayg_efi_var_read_fullname (name, -1, &size, NULL);
   if (!content || size != 1)
     return FALSE;
 

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -553,6 +553,20 @@ eospayg_efi_secureboot_active (void)
   return eospayg_efi_var_read_fullname_boolean (name, NULL);
 }
 
+/* eospayg_efi_setupmode_active:
+ *
+ * Check if the system was booted with SetupMode
+ *
+ * Returns: %TRUE if booted via SetupMode, %FALSE otherwise
+ */
+gboolean
+eospayg_efi_setupmode_active (void)
+{
+  g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SetupMode");
+
+  return eospayg_efi_var_read_fullname_boolean (name, NULL);
+}
+
 /* eospayg_efi_securebootoption_disabled:
  *
  * Check if the SecureBootOption EFI variable exists and

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -544,19 +544,13 @@ efivarfs_read (const char  *name,
 gboolean
 eospayg_efi_secureboot_active (void)
 {
-  g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SecureBoot");
-  g_autofree unsigned char *content = NULL;
-  int size;
-
   /* In test mode let's pretend secure boot is enabled */
   if (test_mode)
     return TRUE;
 
-  content = eospayg_efi_var_read_fullname (name, -1, &size, NULL);
-  if (!content || size != 1)
-    return FALSE;
+  g_autofree char *name = full_efi_name (GLOBAL_VARIABLE_GUID, "SecureBoot");
 
-  return !!content[0];
+  return eospayg_efi_var_read_fullname_boolean (name, NULL);
 }
 
 /* eospayg_efi_securebootoption_disabled:
@@ -662,6 +656,31 @@ eospayg_efi_var_read_fullname (const char  *name,
                               expected_size);
     }
   return ret;
+}
+
+/* eospayg_efi_var_read_fullname_boolean:
+ * @name: Full name of variable
+ * @error: return location for an error, or %NULL
+ *
+ * Read the contents of an EFI variable as a boolean with its full name.
+ *
+ * It only checks the first byte of the EFI variable's content.
+ *
+ * Returns: (transfer full): A boolean of the variable content, or %NULL on
+ *          error
+ */
+gboolean
+eospayg_efi_var_read_fullname_boolean (const char  *name,
+                                       GError     **error)
+{
+  g_autofree unsigned char *content = NULL;
+  int size;
+
+  content = eospayg_efi_var_read_fullname (name, -1, &size, error);
+  if (!content)
+    return FALSE;
+
+  return !!content[0];
 }
 
 /* eospayg_efi_var_read:

--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -41,7 +41,6 @@ static int fake_var_ptr = 0;
 static int efi_fd = -1;
 DIR *efi_dir = NULL;
 static gboolean post_pivot = FALSE;
-static gboolean initted = FALSE;
 static gboolean test_mode = FALSE;
 
 struct efi_ops {
@@ -917,7 +916,7 @@ eospayg_efi_init (enum eospayg_efi_flags   flags,
   glnx_autofd int local_efi_fd = -1;
   glnx_autofd int tmpfd = -1;
 
-  if (initted)
+  if (efi != NULL)
     return TRUE;
 
   if (flags & EOSPAYG_EFI_TEST_MODE)

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -13,6 +13,12 @@ enum eospayg_efi_flags {
   EOSPAYG_EFI_TEST_MODE = 1,
 };
 
+enum efivar_states {
+  EFIVAR_NOT_EXIST = 0,
+  EFIVAR_TRUE,
+  EFIVAR_FALSE,
+};
+
 gboolean eospayg_efi_init (enum eospayg_efi_flags   flags,
                            GError                 **error);
 gboolean eospayg_efi_var_write (const char  *name,
@@ -30,6 +36,7 @@ gboolean eospayg_efi_var_delete_fullname (const char  *name,
 gboolean eospayg_efi_var_exists (const char *name);
 gboolean eospayg_efi_secureboot_active (void);
 gboolean eospayg_efi_setupmode_active (void);
+enum efivar_states eospayg_efi_secureboot_setup_active (void);
 gboolean eospayg_efi_securebootoption_disabled (void);
 int eospayg_efi_PK_size (void);
 gboolean eospayg_efi_var_supported (void);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -29,6 +29,7 @@ gboolean eospayg_efi_var_delete_fullname (const char  *name,
                                           GError     **error);
 gboolean eospayg_efi_var_exists (const char *name);
 gboolean eospayg_efi_secureboot_active (void);
+gboolean eospayg_efi_setupmode_active (void);
 gboolean eospayg_efi_securebootoption_disabled (void);
 int eospayg_efi_PK_size (void);
 gboolean eospayg_efi_var_supported (void);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -39,4 +39,6 @@ void *eospayg_efi_var_read (const char  *name,
                             int          expected_size,
                             int         *size,
                             GError     **error);
+gboolean eospayg_efi_var_read_fullname_boolean (const char  *name,
+                                                GError     **error);
 gboolean eospayg_efi_clear (void);


### PR DESCRIPTION
Introduce eospayg_efi_setupmode() to check the system boots with SetupMode, or not. It check the EFI variable:
SetupMode-8be4df61-93ca-11d2-aa0d-00e098032b8c for normal cases.

https://phabricator.endlessm.com/T34898