### PR TITLE
Add libsystemd-dev dep to -dev package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Section: misc
 Architecture: any
 Depends:
  libglib2.0-dev,
+ libsystemd-dev,
  eos-paygd (= ${binary:Version}),
  ${misc:Depends},
 Description: Pay As You Go Daemon - provider plugin development


### PR DESCRIPTION
Since commit 35b3213, the generated eos-payg-1.pc file has listed
libsystemd as a private dependency, I think because libeos-payg-1
internally links to libsystemd and so any binary that statically links
libeos-payg-1 now links to libsystemd.

```diff
-Requires: gio-2.0, glib-2.0, gobject-2.0
+Requires: gio-2.0 >=  2.44, glib-2.0 >=  2.44, gobject-2.0 >=  2.44
+Requires.private: libsystemd, gio-unix-2.0, libpeas-1.0
```

Add libsystemd-dev as a dependency of the libeos-payg-1-dev package so
that applications which declare the latter as a build dependency can
still build.

https://phabricator.endlessm.com/T35437
