### PR TITLE
Report GError when EFI functions fail

### DIFF
--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -234,10 +234,10 @@ test_and_update_securitylevel (void)
   gboolean ret;
   g_autoptr(GError) error = NULL;
 
-  level = eospayg_efi_var_read ("securitylevel", 1, &data_size);
+  level = eospayg_efi_var_read ("securitylevel", 1, &data_size, &error);
   if (!level)
     {
-      g_warning ("Failed to read security level");
+      g_warning ("Failed to read security level: %s", error->message);
       return FALSE;
     }
 

--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -329,12 +329,14 @@ main (int   argc,
 
       g_debug ("eos-paygd running from initramfs");
 
-      if (!eospayg_efi_init (0))
+      if (!eospayg_efi_init (0, &error))
         {
-          g_warning ("Unable to access EFI variables, shutting down in %d minutes",
-                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES);
+          g_warning ("Unable to access EFI variables, shutting down in %d minutes: %s",
+                     TIMEOUT_POWEROFF_ON_ERROR_MINUTES,
+                     error->message);
           g_timeout_add_seconds (TIMEOUT_POWEROFF_ON_ERROR_MINUTES * 60,
                                  payg_system_poweroff, NULL);
+          g_clear_error (&error);
         }
 
       payg_set_debug_env_vars ();

--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -234,8 +234,8 @@ test_and_update_securitylevel (void)
   gboolean ret;
   g_autoptr(GError) error = NULL;
 
-  level = eospayg_efi_var_read ("securitylevel", &data_size);
-  if (!level || data_size != 1)
+  level = eospayg_efi_var_read ("securitylevel", 1, &data_size);
+  if (!level)
     {
       g_warning ("Failed to read security level");
       return FALSE;

--- a/eos-paygd/main.c
+++ b/eos-paygd/main.c
@@ -232,6 +232,7 @@ test_and_update_securitylevel (void)
   g_autofree char *level = NULL;
   int data_size = 0;
   gboolean ret;
+  g_autoptr(GError) error = NULL;
 
   level = eospayg_efi_var_read ("securitylevel", &data_size);
   if (!level || data_size != 1)
@@ -261,14 +262,14 @@ test_and_update_securitylevel (void)
        * project we probably need to consider alternate career paths.
        */
       level[0] = EPG_SECURITY_LEVEL;
-      ret = eospayg_efi_var_overwrite ("securitylevel", level, data_size);
+      ret = eospayg_efi_var_overwrite ("securitylevel", level, data_size, &error);
 
       /* There's nothing a user should be able to do to cause this to fail,
        * so we'll let this "impossible" situation slide with a warning, and
        * attempt to correct it on next boot.
        */
       if (!ret)
-        g_warning ("Failed to update security level.");
+        g_warning ("Failed to update security level: %s", error->message);
     }
 
   return TRUE;

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -33,5 +33,5 @@ gboolean eospayg_efi_var_supported (void);
 void eospayg_efi_list_rewind (void);
 const char *eospayg_efi_list_next (void);
 void eospayg_efi_root_pivot (void);
-void *eospayg_efi_var_read (const char *name, int *size);
+void *eospayg_efi_var_read (const char *name, int expected_size, int *size);
 gboolean eospayg_efi_clear (void);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -13,7 +13,8 @@ enum eospayg_efi_flags {
   EOSPAYG_EFI_TEST_MODE = 1,
 };
 
-gboolean eospayg_efi_init (enum eospayg_efi_flags flags);
+gboolean eospayg_efi_init (enum eospayg_efi_flags   flags,
+                           GError                 **error);
 gboolean eospayg_efi_var_write (const char *name, const void *content, int size);
 gboolean eospayg_efi_var_overwrite (const char *name, const void *content, int size);
 gboolean eospayg_efi_var_delete (const char *name);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -23,8 +23,10 @@ gboolean eospayg_efi_var_overwrite (const char  *name,
                                     const void  *content,
                                     int          size,
                                     GError     **error);
-gboolean eospayg_efi_var_delete (const char *name);
-gboolean eospayg_efi_var_delete_fullname (const char *name);
+gboolean eospayg_efi_var_delete (const char  *name,
+                                 GError     **error);
+gboolean eospayg_efi_var_delete_fullname (const char  *name,
+                                          GError     **error);
 gboolean eospayg_efi_var_exists (const char *name);
 gboolean eospayg_efi_secureboot_active (void);
 gboolean eospayg_efi_securebootoption_disabled (void);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -15,8 +15,14 @@ enum eospayg_efi_flags {
 
 gboolean eospayg_efi_init (enum eospayg_efi_flags   flags,
                            GError                 **error);
-gboolean eospayg_efi_var_write (const char *name, const void *content, int size);
-gboolean eospayg_efi_var_overwrite (const char *name, const void *content, int size);
+gboolean eospayg_efi_var_write (const char  *name,
+                                const void  *content,
+                                int          size,
+                                GError     **error);
+gboolean eospayg_efi_var_overwrite (const char  *name,
+                                    const void  *content,
+                                    int          size,
+                                    GError     **error);
 gboolean eospayg_efi_var_delete (const char *name);
 gboolean eospayg_efi_var_delete_fullname (const char *name);
 gboolean eospayg_efi_var_exists (const char *name);

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -33,5 +33,8 @@ gboolean eospayg_efi_var_supported (void);
 void eospayg_efi_list_rewind (void);
 const char *eospayg_efi_list_next (void);
 void eospayg_efi_root_pivot (void);
-void *eospayg_efi_var_read (const char *name, int expected_size, int *size);
+void *eospayg_efi_var_read (const char  *name,
+                            int          expected_size,
+                            int         *size,
+                            GError     **error);
 gboolean eospayg_efi_clear (void);

--- a/libeos-payg/service.c
+++ b/libeos-payg/service.c
@@ -558,6 +558,7 @@ static void provider_unlocked_cb (EpgProvider *provider,
                                   gpointer     user_data)
 {
   EpgService *self = EPG_SERVICE (user_data);
+  g_autoptr(GError) error = NULL;
 
   g_message ("EpgProvider emitted 'unlocked' signal");
 
@@ -567,8 +568,8 @@ static void provider_unlocked_cb (EpgProvider *provider,
    */
   if (self->eospayg_active_efivar)
     {
-      if (!eospayg_efi_var_delete ("active"))
-        g_warning ("Failed to delete EOSPAYG_active upon unlock");
+      if (!eospayg_efi_var_delete ("active", &error))
+        g_warning ("Failed to delete EOSPAYG_active upon unlock: %s", error->message);
       else
         g_message ("Deleted EOSPAYG_active upon unlock");
 

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -92,7 +92,7 @@ _read_eospayg_debug (void)
   /* For now we only look at the first byte but let's allow it to be bigger so
    * it can be extended in the future.
    */
-  debug_efivar = eospayg_efi_var_read ("debug", &data_size);
+  debug_efivar = eospayg_efi_var_read ("debug", -1, &data_size);
   if (!debug_efivar)
     {
       g_warning ("Failed to read EOSPAYG_debug");

--- a/libeos-payg/util.c
+++ b/libeos-payg/util.c
@@ -85,6 +85,7 @@ _read_eospayg_debug (void)
   g_autofree unsigned char *debug_efivar = NULL;
   int data_size;
   EpgDebugFlags debug_flags = 0;
+  g_autoptr(GError) error = NULL;
 
   if (!eospayg_efi_var_exists ("debug"))
     return debug_flags;
@@ -92,10 +93,10 @@ _read_eospayg_debug (void)
   /* For now we only look at the first byte but let's allow it to be bigger so
    * it can be extended in the future.
    */
-  debug_efivar = eospayg_efi_var_read ("debug", -1, &data_size);
+  debug_efivar = eospayg_efi_var_read ("debug", -1, &data_size, &error);
   if (!debug_efivar)
     {
-      g_warning ("Failed to read EOSPAYG_debug");
+      g_warning ("Failed to read EOSPAYG_debug: %s", error->message);
       return debug_flags;
     }
 


### PR DESCRIPTION
Previously, many functions to read and manipulate EFI variables would return FALSE or NULL on error, but there was no reliable way to determine the cause of the error. Some error paths would set `errno`, but not all.

Add a `GError **` parameter to these functions, and set it whenever FALSE or NULL is returned.

In addition, extend `eospayg_efi_var_read()` to check whether the variable contents match the caller's expected size, which almost all callers would previously do. This way we only need to write the logic to set the GError in this case once, here, and the callers' error handling is simplified.

I did not add GError ** parameters to the various miscellaneous accessors.

This PR requires the out-of-tree plugins to be updated in lockstep because I chose not to preserve the API & ABI.

https://phabricator.endlessm.com/T35459