### PR TITLE
Re-enable TAP parsing for C tests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  dh-python,
  dracut,
  gtk-doc-tools,
- libglib2.0-dev (>= 2.74),
+ libglib2.0-dev (>= 2.76),
  libpeas-dev,
  libsystemd-dev,
  meson,

--- a/libeos-payg-codes/tests/meson.build
+++ b/libeos-payg-codes/tests/meson.build
@@ -46,5 +46,6 @@ foreach program: test_programs
     exe,
     env: envs,
     suite: ['eos-payg'],
+    protocol: 'tap',
   )
 endforeach

--- a/libeos-payg/tests/meson.build
+++ b/libeos-payg/tests/meson.build
@@ -59,6 +59,7 @@ foreach program_name, extra_args : test_programs
       exe,
       env: envs,
       suite: ['eos-payg'] + suites,
+      protocol: 'tap',
     )
   endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,7 @@ libgsystemservice = subproject('libgsystemservice')
 libgsystemservice_dep = libgsystemservice.get_variable('libgsystemservice_dep')
 
 glib_major_version = '2'
-glib_minor_version = '74'
+glib_minor_version = '76'
 glib_dep_version = '>= @0@.@1@'.format(glib_major_version, glib_minor_version)
 glib_version_define = 'GLIB_VERSION_@0@_@1@'.format(glib_major_version, glib_minor_version)
 


### PR DESCRIPTION
This reverts commit 2f1171b16ecd5e9d4e042e8faac1eae452a6340c, which reverted part of commit 15f0d9319f29c56cdd345b67892013786084921b.

We now have a newer GLib which emits the "TAP version XX" header, so let's try again to tell Meson that the C tests emit TAP output, and bump the GLib dependency to the version that added that header.