### PR TITLE
efi: Drop eospayg_efi_securebootoption_disabled

### DIFF
--- a/libeos-payg/efi.c
+++ b/libeos-payg/efi.c
@@ -20,8 +20,6 @@
 #define GLOBAL_VARIABLE_GUID    "8be4df61-93ca-11d2-aa0d-00e098032b8c"
 #define SECUREBOOT_SETUP_GUID   "7b59104a-c00d-4158-87ff-f04d6396a915"
 
-/* Can't figure out who owns this GUID. ECS and Lenovo have both used it */
-#define SBO_VARIABLE_GUID       "955b9041-133a-4bcf-90d1-97e1693c0e30"
 #define NVM_PREFIX              "EOSPAYG_"
 
 /* Totally bogus low performance mock storage for dry runs.
@@ -602,42 +600,6 @@ eospayg_efi_secureboot_setup_active (void)
     return EFIVAR_NOT_EXIST;
 
   return flag ? EFIVAR_TRUE : EFIVAR_FALSE;
-}
-
-/* eospayg_efi_securebootoption_disabled:
- *
- * Check if the SecureBootOption EFI variable exists and
- * is disabled.
- *
- * The oddly inverted logic is due to the fact that most
- * systems don't have this variable at all - if it doesn't
- * exist, we can infer nothing about the state of Secure Boot,
- * if it does it tells us if the Secure Boot option in the
- * BIOS is enabled or disabled.
- *
- * Thus, on and not existing should likely be treated in the
- * same way by a caller, but existing and off is a red flag
- * for PAYG enforcement.
- *
- * Returns: %TRUE if the variable exists and is disabled, %FALSE otherwise
- */
-gboolean
-eospayg_efi_securebootoption_disabled (void)
-{
-  g_return_val_if_fail (efi != NULL, FALSE);
-
-  g_autofree char *tname = full_efi_name (SBO_VARIABLE_GUID, "SecureBootOption");
-  g_autofree unsigned char *content = NULL;
-  int size;
-
-  if (test_mode)
-    return FALSE;
-
-  content = efivarfs_read (tname, &size, NULL);
-  if (!content || size != 1)
-    return FALSE;
-
-  return !content[0];
 }
 
 /* eospayg_efi_PK_size:

--- a/libeos-payg/efi.h
+++ b/libeos-payg/efi.h
@@ -37,7 +37,6 @@ gboolean eospayg_efi_var_exists (const char *name);
 gboolean eospayg_efi_secureboot_active (void);
 gboolean eospayg_efi_setupmode_active (void);
 enum efivar_states eospayg_efi_secureboot_setup_active (void);
-gboolean eospayg_efi_securebootoption_disabled (void);
 int eospayg_efi_PK_size (void);
 gboolean eospayg_efi_var_supported (void);
 void eospayg_efi_list_rewind (void);


### PR DESCRIPTION
The function eospayg_efi_securebootoption_disabled() was used for provisioning EF20(EA). However, EF20(EA) has been EOL [1] and eos-payg-nonfree does not invoke it anymore. So, drop it.

[1]: https://phabricator.endlessm.com/T33759

https://phabricator.endlessm.com/T35604