### PR TITLE
eos-paygd: Introduce eos-paygd-3.service for Phase 2 with eospayg

### DIFF
--- a/debian/eos-paygd.install
+++ b/debian/eos-paygd.install
@@ -1,5 +1,6 @@
 lib/systemd/system/eos-paygd.service
 lib/systemd/system/eos-paygd-2.service
+lib/systemd/system/eos-paygd-3.service
 usr/lib/tmpfiles.d/eos-paygd.conf
 usr/lib/*/eos-payg-1/libeos-payg-1.so
 usr/lib/*/eos-paygd1

--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,10 @@ override_dh_auto_test:
 
 # Don't start the services on install
 override_dh_systemd_start:
-	dh_systemd_start -peos-paygd --no-start eos-paygd.service eos-paygd-2.service
+	dh_systemd_start -peos-paygd --no-start \
+		eos-paygd.service \
+		eos-paygd-2.service \
+		eos-paygd-3.service
 
 override_dh_missing:
 	dh_missing --fail-missing

--- a/eos-paygd/eos-paygd-3.service.in
+++ b/eos-paygd/eos-paygd-3.service.in
@@ -1,14 +1,16 @@
 [Unit]
 Description=Pay As You Go Daemon
 Documentation=man:eos-paygd(8)
-# Only run on Phase 2 PAYG systems without kernel parameter eospayg
-ConditionKernelCommandLine=!eospayg
+# Only run on Phase 2 PAYG systems with kernel parameter eospayg on non-x86_64
+ConditionKernelCommandLine=eospayg
+ConditionArchitecture=!x86-64
+ConditionPathExists=!/sys/firmware/efi
 Before=systemd-user-sessions.service
 
 [Service]
 ExecStart=@libexecdir@/eos-paygd1
-Type=dbus
-BusName=com.endlessm.Payg1
+# Type=dbus using the same BusName would conflict to eos-paygd.service
+Type=notify
 NotifyAccess=main
 # We must be root to make the eMMC boot partition writable
 User=root

--- a/eos-paygd/meson.build
+++ b/eos-paygd/meson.build
@@ -55,6 +55,13 @@ configure_file(
   install_dir: systemdsystemunitdir,
   configuration: config,
 )
+# eos-paygd service for Phase 2 PAYG systemswith kernel parameter eospayg on non-x86_64
+configure_file(
+  input: 'eos-paygd-3.service.in',
+  output: 'eos-paygd-3.service',
+  install_dir: systemdsystemunitdir,
+  configuration: config,
+)
 # eos-paygd tmpfile for maintaining logs directory
 install_data(
   'eos-paygd.tmpfile',


### PR DESCRIPTION
Some Endless PAYG system need kernel parameter "eospayg" as a flag to teach OSTree deploys an EOS PAYG style image [1], but lack EFI variable feature, such as EOS RPi PAYG. [2] So, those lacking EFI variable system still belong to PAYG Phase 2 level. And, these are non-x86_64 platforms. Therefore, introduce eos-paygd-3.service to handle the EOS PAYG system having kernel parameter eospayg, but running on non-x86_64 and lacking EFI variable environment.

[1]: https://github.com/endlessm/ostree/pull/157
[2]: https://github.com/endlessm/ostree/pull/215

https://app.asana.com/1/1203676861188277/project/1211949321657103/task/1216023738797721